### PR TITLE
Fix typo on toolbar

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -49,7 +49,7 @@
 				"warning-distinct-missing": "DISTINCT is missing; relational algebra uses implicit duplicate elimination",
 				"warning-ignored-all-on-set-operators": "ignored ALL on set operation; relational algebra uses implicit duplicate elimination",
 				"error-variable-name-conflict": "name conflict: relation name \"__name__\" already exists",
-				"error-variable-cyclic-usage": "cylic usage of variable \"__name__\" detected"
+				"error-variable-cyclic-usage": "cyclic usage of variable \"__name__\" detected"
 			}
 		}
 	},

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -122,7 +122,7 @@
 				"tab-name": "Group Editor",
 				"toolbar": {
 					"import-sql": "import SQL-dump",
-					"import-sql-content": "import SQL-dump",
+					"import-sql-content": "import SQL-content",
 					"add-new-relation": "add new relation",
 					"add-new-relation-content": "open relation editor"
 				},


### PR DESCRIPTION
I found the typo on translation.json file like [below commit](https://github.com/dbis-uibk/relax/pull/16/commits/3b78cfbe4b5ffc51336b34581782204d6b14df02)