### PR TITLE
Fix wrong date format crash

### DIFF
--- a/src/db/exec/ValueExpr.ts
+++ b/src/db/exec/ValueExpr.ts
@@ -386,6 +386,8 @@ export class ValueExprGeneric extends ValueExpr {
 				return true;
 
 			case 'date':
+				// Check wether the date format is valid
+				this._parseIsoDate(this._args[0]._args[0]);
 				return this._checkArgsDataType(schemaA, schemaB, ['string']);
 
 			case 'adddate':

--- a/src/db/tests/translate_tests_ra.ts
+++ b/src/db/tests/translate_tests_ra.ts
@@ -1073,6 +1073,17 @@ QUnit.test('pi with eval: date', function (assert) {
 	assert.deepEqual(result, reference);
 });
 
+QUnit.test('pi with wrong date format', function (assert) {
+	try {
+		const query = "pi date('01-01-1970')->d (R)";
+		exec_ra(query, getTestRelations());
+		assert.ok(false);
+	}
+	catch (e) {
+		assert.ok(true);
+	}
+});
+
 QUnit.test('pi with eval: upper()', function (assert) {
 	const relations = getTestRelations();
 	const result = exec_ra(" sigma x < 'D' pi upper(S.b)->x S ", relations).getResult();


### PR DESCRIPTION
# Reference issue (#199)

The current implementation does not check the date format while writing a query and the application crashes in case the expected pattern is not used.

# What does this implement/fix?

This PR aims at not only fixing the bug by showing an error message if the problematic query is executed, but also allowing for checking wether the date format is valid while writing a query.

**Note:** To run the tests refer to the dataset and query presented at #199

- Before:

While editing...
<img width="1273" alt="Screen Shot 2024-04-11 at 08 51 42" src="https://github.com/dbis-uibk/relax/assets/4059310/b01f9cd4-e67f-47c7-bdfc-dfcba9ebef1a">

If executed...
<img width="1274" alt="Screen Shot 2024-04-11 at 08 52 33" src="https://github.com/dbis-uibk/relax/assets/4059310/a0344fd1-1f48-4443-b4cb-500111de6e95">

- After:

<img width="1116" alt="Screen Shot 2024-04-10 at 13 09 51" src="https://github.com/dbis-uibk/relax/assets/4059310/0662b138-4858-46b7-932c-98841c2e2b52">

<img width="1115" alt="Screen Shot 2024-04-10 at 13 04 49" src="https://github.com/dbis-uibk/relax/assets/4059310/80615798-c3ee-4b3f-8219-faed21a25930">

# How to test this PR?

Test it live at https://rlaiola.github.io/relax/ using the dataset and query presented at #199.
