### PR TITLE
Fix description of group by example in documentation

### DIFF
--- a/src/calc2/views/help.tsx
+++ b/src/calc2/views/help.tsx
@@ -1220,7 +1220,7 @@ export class Help extends React.Component<Props> {
 									<br />and a list of aggregate functions to apply with their new name in form <span>AGG( COLUMN ) -{'>'} NEW_NAME</span>
 
 									<div className="example">
-										order the result by the first column (default is ascending) and the second column descending:
+										group the result by columns a and b, and within each group sum the values in c into a column named x:
 										<code>&gamma; a, b ; sum(c)-{'>'}x ( Customer )</code>
 									</div>
 


### PR DESCRIPTION
# Reference issue

None.

# What does this implement/fix?

This PR fixes the description of the group by example presented in the documentation. The current one seems a copy and paste from the order by example.

# How to test this PR?

Test it live at https://rlaiola.github.io/relax/help#relalg-operations-groupby.

