### PR TITLE
:bug: fix date check crash

### DIFF
--- a/src/calc2/components/editorBagalg.tsx
+++ b/src/calc2/components/editorBagalg.tsx
@@ -100,6 +100,7 @@ export class EditorBagalg extends React.Component<Props, State> {
 					return {
 						result: (
 							<Result
+								editorRef={this.editorBase!}
 								root={root}
 								numTreeLabelColors={NUM_TREE_LABEL_COLORS}
 								execTime={self.state.execTime == null ? 0 : self.state.execTime}

--- a/src/calc2/components/editorRelalg.tsx
+++ b/src/calc2/components/editorRelalg.tsx
@@ -100,6 +100,7 @@ export class EditorRelalg extends React.Component<Props, State> {
 					return {
 						result: (
 							<Result
+								editorRef={this.editorBase!}
 								root={root}
 								numTreeLabelColors={NUM_TREE_LABEL_COLORS}
 								execTime={self.state.execTime == null ? 0 : self.state.execTime}

--- a/src/calc2/components/editorSql.tsx
+++ b/src/calc2/components/editorSql.tsx
@@ -90,6 +90,7 @@ export class EditorSql extends React.Component<Props> {
 						return {
 							result: (
 								<Result
+									editorRef={this.editorBase!}
 									root={root}
 									numTreeLabelColors={NUM_TREE_LABEL_COLORS}
 									execTime={self.state.execTime == null ? 0 : self.state.execTime}

--- a/src/calc2/components/result.tsx
+++ b/src/calc2/components/result.tsx
@@ -11,12 +11,15 @@ import { Table } from 'db/exec/Table';
 import memoize from 'memoize-one';
 import * as React from 'react';
 import {t} from "calc2/i18n";
+import { EditorBase } from './editorBase';
+import { ExecutionError } from 'db/exec/ExecutionError';
 
 require('./result.scss');
 
 const maxLinesPerPage = 10;
 
 type Props = {
+	editorRef: EditorBase,
 	root: RANode,
 	numTreeLabelColors: number,
 	execTime?: any,
@@ -38,8 +41,7 @@ export class Result extends React.Component<Props, State> {
 				return node.getResult(doEliminateDuplicates);
 			}
 			catch (e) {
-				console.error(e);
-				return null;
+				return e;
 			}
 		},
 	);
@@ -64,11 +66,15 @@ export class Result extends React.Component<Props, State> {
 	}
 
 	render() {
-		const { root, numTreeLabelColors, execTime, doEliminateDuplicates } = this.props;
+		const { editorRef, root, numTreeLabelColors, execTime, doEliminateDuplicates } = this.props;
 		const { activeNode } = this.state;
 
 		const result = this.result(activeNode, doEliminateDuplicates);
-
+		if (result instanceof ExecutionError) {
+			const errorMessage = result.message;
+			editorRef.addExecutionError(errorMessage);
+			return;
+		}
 
 		return (
 			<div className="ra-result clearfix">

--- a/src/db/exec/ValueExpr.ts
+++ b/src/db/exec/ValueExpr.ts
@@ -387,7 +387,9 @@ export class ValueExprGeneric extends ValueExpr {
 
 			case 'date':
 				// Check wether the date format is valid
-				this._parseIsoDate(this._args[0]._args[0]);
+				if (this?._args?.[0]?._args?.[0]) {
+					this._parseIsoDate(this._args[0]._args[0]);
+				}
 				return this._checkArgsDataType(schemaA, schemaB, ['string']);
 
 			case 'adddate':

--- a/src/db/exec/ValueExpr.ts
+++ b/src/db/exec/ValueExpr.ts
@@ -387,7 +387,7 @@ export class ValueExprGeneric extends ValueExpr {
 
 			case 'date':
 				// Check wether the date format is valid
-				if (this?._args?.[0]?._args?.[0]) {
+				if (this?._args?.[0]?._args?.[0] !== undefined) {
 					this._parseIsoDate(this._args[0]._args[0]);
 				}
 				return this._checkArgsDataType(schemaA, schemaB, ['string']);

--- a/src/db/parser/grammar_bags.d.ts
+++ b/src/db/parser/grammar_bags.d.ts
@@ -345,11 +345,6 @@ declare module relalgAst {
 
 
 	type ValueExprFunction = (
-		| 'reverse'
-		| 'replace'
-		| 'repeat'
-		| 'rlike'
-		| 'regexp'
 		| 'constant'
 		| 'columnValue'
 		| 'or'

--- a/src/db/parser/grammar_bags.d.ts
+++ b/src/db/parser/grammar_bags.d.ts
@@ -345,6 +345,11 @@ declare module relalgAst {
 
 
 	type ValueExprFunction = (
+		| 'reverse'
+		| 'replace'
+		| 'repeat'
+		| 'rlike'
+		| 'regexp'
 		| 'constant'
 		| 'columnValue'
 		| 'or'


### PR DESCRIPTION
The date check, implemented on #201 was causing a crash when a conversion to data was being performed. That happens because when a field of type date is referenced there's no string args to check, which causes an exception trying to access undefined. 

In this PR i also fix the **ValueExprFunction** typescript types. There were missing types related to a new implementation of **reverse**, **replace**, **repeat**, **rlike** and **regexp**.

The error was: 
![image](https://github.com/user-attachments/assets/9f078355-7405-49e6-897b-4684437d3c2c)

Now it works:
![image](https://github.com/user-attachments/assets/3ccf7fc8-b8f6-4fd2-b596-424b3e4ae4a6)
