### PR TITLE
Follow-up Changes for PR #224 – Restore Groups and Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"scripts": {
 		"build": "webpack --progress --mode=production",
 		"build-test": "webpack -p --progress --colors --mode=development",
-		"serve": "webpack-dev-server --hot --mode=development"
+		"serve": "NODE_OPTIONS=--openssl-legacy-provider webpack-dev-server --hot --mode=development"
 	},
 	"name": "relax-relational_algebra_calculator",
 	"private": true,

--- a/src/calc2/index.ejs
+++ b/src/calc2/index.ejs
@@ -26,7 +26,21 @@
 	<link rel="mask-icon" href="assets/favicon/safari-pinned-tab.svg" color="#007bff">
 	<meta name="msapplication-TileColor" content="#da532c">
 	<meta name="theme-color" content="#ffffff">
-
+	<script>
+		(function (i, s, o, g, r, a, m) {
+			i['GoogleAnalyticsObject'] = r;
+			i[r] = i[r] || function () {
+				(i[r].q = i[r].q || []).push(arguments)
+			}, i[r].l = 1 * new Date();
+			a = s.createElement(o),
+				m = s.getElementsByTagName(o)[0];
+			a.async = 1;
+			a.src = g;
+			m.parentNode.insertBefore(a, m)
+		})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+		ga('create', 'UA-53545936-1', 'auto');
+		ga('send', 'pageview');
+	</script>
 	<!-- Start Single Page Apps for GitHub Pages -->
 	<script type="text/javascript">
 		// Single Page Apps for GitHub Pages

--- a/src/calc2/main.tsx
+++ b/src/calc2/main.tsx
@@ -64,7 +64,7 @@ export class Main extends React.Component<Props, State> {
 								<Route path="/relax/landing" component={Landing} />
 								<Route path="/relax/help" component={Help} />
 								<Route path="/relax/imprint" component={Imprint} />
-								<Redirect from="/relax/calc" to="/relax/calc/local/sb/local/0" exact strict />
+								<Redirect from="/relax/calc" to="/relax/calc/local/uibk/local/0" exact strict />
 								<Route path="/relax/calc/:source/:id/:filename/:index" component={ConnectedCalc} />
 								<Route path="/relax/calc/:source/:id" component={ConnectedCalc} />
 								<Route path="/relax/api/:source/:id/:filename/:index" component={ConnectedCalc} />

--- a/src/calc2/store/groups.ts
+++ b/src/calc2/store/groups.ts
@@ -246,25 +246,95 @@ export function loadStaticGroups() {
 		id: string,
 	}[] = [
 		{
-			maintainerGroup: t('calc.maintainer-groups.savben'),
-			maintainer: '<a href="https://github.com/gionata">Gionata Massi</a>',
-			
-			source: 'local',
-			id: 'sb',
-		},
-		{
-			maintainerGroup: t('calc.maintainer-groups.ufes'),
-			maintainer: '<a href="https://github.com/rlaiola">Rodrigo Laiola Guimaraes</a>',
-
-			source: 'local',
-			id: 'ufes',
-		},
-		{
 				maintainerGroup: t('calc.maintainer-groups.misc'),
 				maintainer: '',
 
 				source: 'local',
 				id: 'uibk',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.uibk'),
+				maintainer: '<a href="https://github.com/mtschu">mtschu</a>',
+
+				source: 'gist',
+				id: '2923a30a474fdcb46bee',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.uibk'),
+				maintainer: '<a href="https://gist.github.com/woolfg">Wolfgang Gassler</a>',
+
+				source: 'gist',
+				id: '7d1871f79a8bcb4788de',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.karlsruhe'),
+				maintainer: '<a href="https://github.com/jstoess">Jan Stoess</a>',
+
+				source: 'gist',
+				id: '4f7866c17624ca9dfa85ed2482078be8',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.karlsruhe'),
+				maintainer: '<a href="https://github.com/jstoess">Jan Stoess</a>',
+
+				source: 'gist',
+				id: 'a287f5ad991c08a74f55c06789c95508',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.saarland'),
+				maintainer: '<a href="https://gist.github.com/jensdittrich">Jens Dittrich</a>',
+
+				source: 'gist',
+				id: '41cf5ce652756d9331eec7562644e074',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.saarland'),
+				maintainer: '<a href="https://gist.github.com/jensdittrich">Jens Dittrich</a>',
+
+				source: 'gist',
+				id: 'c306ecf21c6e6d175508d3ac6b4355e7',
+			},
+
+			{
+				maintainerGroup: t('calc.maintainer-groups.hsd'),
+				maintainer: '<a href="https://gist.github.com/mafo3186">Mareike Focken</a>',
+
+				source: 'gist',
+				id: 'dd9b9e4a5bd3b9a5265104e4c8f171c6',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.hsd'),
+				maintainer: '<a href="https://gist.github.com/mafo3186">Mareike Focken</a>',
+
+				source: 'gist',
+				id: '7716a847139f098709a88f1835d5b08b',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.hsd'),
+				maintainer: '<a href="https://gist.github.com/mafo3186">Mareike Focken</a>',
+
+				source: 'gist',
+				id: 'd37f667154aec34f5c4954723ae01db9',
+			},
+			{
+				maintainerGroup: 'OTH Regensburg',
+				maintainer: '<a href="https://gist.github.com/jschildgen">Johannes Schildgen</a>',
+				source: 'gist',
+				id: 'd67f16874b528abc6e6c88d07a50b2dc',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.savben'),
+				maintainer: '<a href="https://github.com/gionata">Gionata Massi</a>',
+
+				source: 'local',
+				id: 'sb',
+			},
+			{
+				maintainerGroup: t('calc.maintainer-groups.ufes'),
+				maintainer: '<a href="https://github.com/rlaiola">Rodrigo Laiola Guimaraes</a>',
+
+				source: 'local',
+				id: 'ufes',
 			},
 		];
 


### PR DESCRIPTION
This pull request contains additional modifications that complement PR #224.

• Restores the deleted GitHub Gist groups that were removed in PR #224.
• Sets "uibk" as the default group to ensure proper integration.
• Restores the Google Analytics
• Includes an extra fix for the serve command by adding the --openssl-legacy-provider flag to support Node.js v17.
