### PR TITLE
Fix bug in tau / order by operator

### DIFF
--- a/src/db/exec/OrderBy.ts
+++ b/src/db/exec/OrderBy.ts
@@ -110,7 +110,7 @@ export class OrderBy extends RANodeUnary {
 				if (index === -1) {
 					// Column not found
 					try {
-						schema.getColumnIndex(col.getName(), col.getRelAlias());
+						index = schema.getColumnIndex(col.getName(), col.getRelAlias());
 					}
 					catch (e) {
 						this.throwExecutionError(e.message);


### PR DESCRIPTION
# Reference issue

https://github.com/dbis-uibk/relax/issues/239

# What does this implement/fix?

This PR fixes the crash bug in the `tau` operator (order by) reported in https://github.com/dbis-uibk/relax/issues/239.

> Example 1, Set the IMDB-sample database as your dataset.
> 
> * The following query works:
>   π movies.name, movies_genres.genre, movies.rank ( movies ⨝ movies_genres )
> * Add a sort operation and it breaks (the following query breaks the page):
> 
> τ movies.rank desc (π movies.name, movies_genres.genre, movies.rank (σ movies.rank ≥ 8 ( movies ⨝ movies_genres ) ) )

![Screenshot 2025-04-16 at 08 30 16](https://github.com/user-attachments/assets/3a5437c2-a2f4-4b00-9053-933751a62fc6)

> Example 2, Set the DBS1 MovieDB as your dataset.
> 
> * the following query works:
>   π Movies.Title, Genres.Name, Movies.Profit
>   (σ Movies.Profit ≥ 503974884
>   (Movies ⨝ Genres))
> * Add a sort operation and it breaks (the following query breaks the page):
>   τ Movies.Profit
>   (π Movies.Title, Genres.Name, Movies.Profit
>   (σ Movies.Profit ≥ 503974884
>   (Movies ⨝ Genres)))

![Screenshot 2025-04-16 at 08 30 45](https://github.com/user-attachments/assets/02dd594b-a47b-44d6-9e11-0569e8e5c86f)

> However, changing the projection order as follows, the page will crash:
> 
> ```
> τ R.a desc
> (
>  π R.c, S.d, R.a
>  (
>   (R ⨝ S)
>  )
> )
> ```

![Screenshot 2025-04-16 at 08 36 48](https://github.com/user-attachments/assets/43e2cf52-8592-4bb5-85cc-b322d9a1ef9a)


