### PR TITLE
Fix variable replacer tests

### DIFF
--- a/src/db/parser/grammar_bags.d.ts
+++ b/src/db/parser/grammar_bags.d.ts
@@ -42,7 +42,9 @@ declare module bagsAst {
 	type assignment = {
 		type: 'assignment',
 		name: string,
-		child: relalgOperation,
+		child: {
+			assignmentName?: string,
+		} & relalgOperation
 		child2?: undefined,
 		assignments?: undefined,
 
@@ -236,8 +238,12 @@ declare module bagsAst {
 	}
 
 	interface binaryRelalgOperation {
-		child: relalgOperation,
-		child2: relalgOperation,
+		child: {
+			assignmentName?: string,
+		} & relalgOperation,
+		child2: {
+			assignmentName?: string,
+		} & relalgOperation,
 		assignments?: undefined,
 
 		wrappedInParentheses?: boolean,

--- a/src/db/parser/grammar_ra.d.ts
+++ b/src/db/parser/grammar_ra.d.ts
@@ -42,7 +42,9 @@ declare module relalgAst {
 	type assignment = {
 		type: 'assignment',
 		name: string,
-		child: relalgOperation,
+		child: {
+			assignmentName?: string,
+		} & relalgOperation
 		child2?: undefined,
 		assignments?: undefined,
 
@@ -236,8 +238,12 @@ declare module relalgAst {
 	}
 
 	interface binaryRelalgOperation {
-		child: relalgOperation,
-		child2: relalgOperation,
+		child: {
+			assignmentName?: string,
+		} & relalgOperation,
+		child2: {
+			assignmentName?: string,
+		} & relalgOperation,
 		assignments?: undefined,
 
 		wrappedInParentheses?: boolean,

--- a/src/db/tests/var_replacer_tests.ts
+++ b/src/db/tests/var_replacer_tests.ts
@@ -226,6 +226,7 @@ QUnit.test('test variables (unreplaced)', function (assert) {
 				type: 'assignment',
 				name: 'A',
 				child: {
+					assignmentName: 'A',
 					type: 'relation',
 					name: 'firstRelation',
 					codeInfo: mockCodeInfo(),
@@ -236,6 +237,7 @@ QUnit.test('test variables (unreplaced)', function (assert) {
 				type: 'assignment',
 				name: 'B',
 				child: {
+					assignmentName: 'B',
 					type: 'relation',
 					name: 'secondRelation',
 					codeInfo: mockCodeInfo(),
@@ -304,6 +306,7 @@ QUnit.test('test variables (replaced)', function (assert) {
 			child: {
 				type: 'union',
 				child: {
+					assignmentName: 'A',
 					metaData: {
 						fromVariable: 'A',
 					},
@@ -312,6 +315,7 @@ QUnit.test('test variables (replaced)', function (assert) {
 					name: 'firstRelation',
 				},
 				child2: {
+					assignmentName: 'B',
 					metaData: {
 						fromVariable: 'B',
 					},
@@ -363,6 +367,7 @@ QUnit.test('test variables (replaced)', function (assert) {
 				type: 'assignment',
 				name: 'A',
 				child: {
+					assignmentName: 'A',
 					metaData: {
 						fromVariable: 'A',
 					},
@@ -376,6 +381,7 @@ QUnit.test('test variables (replaced)', function (assert) {
 				type: 'assignment',
 				name: 'B',
 				child: {
+					assignmentName: 'B',
 					metaData: {
 						fromVariable: 'B',
 					},
@@ -415,6 +421,7 @@ QUnit.test('test variables without cycle', function (assert) {
 			child: {
 				type: 'union',
 				child: {
+					assignmentName: 'A',
 					metaData: {
 						fromVariable: 'C',
 					},
@@ -423,6 +430,7 @@ QUnit.test('test variables without cycle', function (assert) {
 					codeInfo: mockCodeInfo(),
 				},
 				child2: {
+					assignmentName: 'B',
 					metaData: {
 						fromVariable: 'B',
 					},
@@ -440,6 +448,7 @@ QUnit.test('test variables without cycle', function (assert) {
 				type: 'assignment',
 				name: 'A',
 				child: {
+					assignmentName: 'A',
 					metaData: {
 						fromVariable: 'A',
 					},
@@ -453,6 +462,7 @@ QUnit.test('test variables without cycle', function (assert) {
 				type: 'assignment',
 				name: 'B',
 				child: {
+					assignmentName: 'B',
 					metaData: {
 						fromVariable: 'B',
 					},
@@ -466,6 +476,7 @@ QUnit.test('test variables without cycle', function (assert) {
 				type: 'assignment',
 				name: 'C',
 				child: {
+					assignmentName: 'A',
 					metaData: {
 						fromVariable: 'A',
 					},


### PR DESCRIPTION
# Reference issue

None.

# What does this implement/fix?

This PR fixes the variable replacer tests (5 in total). Keeping the unit tests updated is helpful to try out whether incoming PRs will break something.

- Before (https://dbis-uibk.github.io/relax/test.html)

<img width="1217" alt="Screenshot 2025-04-21 at 11 15 11" src="https://github.com/user-attachments/assets/eb01e568-04f8-4e75-ba4e-069acdfb7447" />

- After

<img width="1213" alt="Screenshot 2025-04-21 at 11 16 06" src="https://github.com/user-attachments/assets/9a930bd1-1233-491d-808f-865ea324bc28" />
