### PR TITLE
fix combined aggregate functions

### DIFF
--- a/src/db/parser/grammar_trc.pegjs
+++ b/src/db/parser/grammar_trc.pegjs
@@ -83,9 +83,9 @@ all
     }
 
 TRC_Expr
-  = '{' _ proj: (listOfNamedColumnExpressions / listOfColumns) _ '|' _ formula:Formula _ '}' 
+  = '{' _ proj: (listOfNamedColumnExpressions / listOfColumns)+ _ '|' _ formula:Formula _ '}' 
 	{
-		const nonUniquevariables = proj.flatMap(p => {
+		const nonUniquevariables = proj[0].flatMap(p => {
 			if (p.type === 'namedColumnExpr' && p.child.func === 'columnValue') {
 				return [p.child.args[1]]
 			}
@@ -95,9 +95,15 @@ TRC_Expr
 			return [p.relAlias ? p.relAlias : p.name]
 		})
 		.filter(v => v)
+		.map(v => {
+			if (typeof v === 'object' && v.type === 'valueExpr') {
+				return v.args[1]
+			}
+			return v
+		})
 
 		const variables = [...new Set(nonUniquevariables)]
-		return createTrcRoot(variables, formula, proj)
+		return createTrcRoot(variables, formula, proj[0])
 	}
 
 Formula = LogicalExpression


### PR DESCRIPTION
Fixes the issue #243. 

@rlaiola The issue was that the TRC grammar wasn't ready to handle nested calls like the one you've exemplified. This MR fixes it by allowing the user to pass a list of expressions instead of only one.

Now it works as expected:

![Screenshot 2025-04-26 at 21 05 06](https://github.com/user-attachments/assets/282748fb-db0e-42e1-b9fe-94082c425272)
