### PR TITLE
Fix Sass deprecation warning

### DIFF
--- a/src/calc2/components/raTree.scss
+++ b/src/calc2/components/raTree.scss
@@ -5,9 +5,9 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .ra-tree {
-	@import './raTreeFamilyTree';
-
 	font-size: 18px;
+
+	@import './raTreeFamilyTree';
 	
 	li .node {
 		cursor: pointer;


### PR DESCRIPTION
# Reference issue

None.

# What does this implement/fix?

This PR gets rid of a Sass deprecation warning that is exhibited when building RelaX.

> Deprecation Warning: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested behavior, rule. To opt into the new behavior, wrap the declaration in '& {}'.

- Before

<img width="751" alt="Screenshot 2025-07-03 at 21 45 01" src="https://github.com/user-attachments/assets/5881ea22-95dc-4e11-bd31-bcf152790c2a" />

- After

<img width="666" alt="Screenshot 2025-07-03 at 21 53 47" src="https://github.com/user-attachments/assets/ec0084fd-533e-49b5-9030-4e49944a9e86" />
