### PR TITLE
Bug fix and enhancements to the TRC implementation

### DIFF
--- a/src/db/parser/grammar_trc.d.ts
+++ b/src/db/parser/grammar_trc.d.ts
@@ -14,12 +14,10 @@ declare namespace trcAst {
 	interface TRC_Expr {
 		type: 'TRC_Expr',
 		variables: string[],
-		projections: Projection[],
+		projections: relalgAst.projection,
 		formula: LogicalExpression,
 		codeInfo: CodeInfo
 	}
-
-	type Projection = (relalgAst.columnName | relalgAst.namedColumnExpr)[]
 
 	interface LogicalExpression {
 		type: 'LogicalExpression',

--- a/src/db/parser/grammar_trc.pegjs
+++ b/src/db/parser/grammar_trc.pegjs
@@ -428,7 +428,7 @@ expr_rest_boolean_comparison
 			codeInfo: getCodeInfo()
 		};
 	}
-/ _ o:('like'i / 'ilike'i) _ right:valueExprConstants
+/ _ o:('like'i / 'ilike'i / 'rlike'i / 'regexp'i) _ right:valueExprConstants
 	{
 		if(right.datatype !== 'string'){
 			error(t('db.messages.parser.error-valueexpr-like-operand-no-string'));
@@ -512,7 +512,7 @@ valueExprFunctionsNary
 	/ ('concat'i { return ['concat', 'string']; })
 	/ ('replace'i { return ['replace', 'string']; })
 )
-'(' _ arg0:valueExpr _ argn:(',' _ valueExpr _ )* ')'
+_ '(' _ arg0:valueExpr _ argn:(',' _ valueExpr _ )* ')'
 	{
 		var args = [arg0];
 		for(var i = 0; i < argn.length; i++){
@@ -612,7 +612,7 @@ valueExprFunctionsBinary
 	/ ('log'i { return ['log', 'number']; })
 	/ ('repeat'i { return ['repeat', 'string']; })
 )
-'(' _ arg0:valueExpr _ ',' _ arg1:valueExpr _ ')'
+_ '(' _ arg0:valueExpr _ ',' _ arg1:valueExpr _ ')'
 	{
 		return {
 			type: 'valueExpr',
@@ -803,7 +803,7 @@ reference: https://dev.mysql.com/doc/refman/5.7/en/operator-precedence.html
 2: - (unary minus)
 3: *, /, %
 4: -, +
-5: = (comparison), >=, >, <=, <, <>, !=, IS, LIKE
+5: = (comparison), >=, >, <=, <, <>, !=, IS, LIKE, ILIKE, RLIKE, REGEXP
 6: CASE, WHEN, THEN, ELSE
 7: AND
 8: XOR

--- a/src/db/parser/grammar_trc.pegjs
+++ b/src/db/parser/grammar_trc.pegjs
@@ -83,21 +83,47 @@ all
     }
 
 TRC_Expr
-  = '{' _ proj: (listOfNamedColumnExpressions / listOfColumns) _ '|' _ formula:Formula _ '}' 
+  = '{' _ proj: (listOfNamedColumnExpressions / listOfColumns) _ '|' _ formula:Formula _ '}'
 	{
-		const nonUniquevariables = proj.flatMap(p => {
-			if (p.type === 'namedColumnExpr' && p.child.func === 'columnValue') {
-				return [p.child.args[1]]
-			}
-			if (p.type === 'namedColumnExpr') {
-				return p.child.args.map(a => a.args[1])
-			}
-			return [p.relAlias ? p.relAlias : p.name]
-		})
-		.filter(v => v)
+		function collectVariableNames(obj, found = new Set()) {
+			if (Array.isArray(obj)) {
+				obj.forEach(item => collectVariableNames(item, found));
+			} else if (obj && typeof obj === 'object') {
+				// columnValue("col", "alias") → use alias
+				if (obj.func === 'columnValue' && Array.isArray(obj.args) && obj.args.length > 1) {
+					const variable = obj.args[1];
+					if (typeof variable === 'string') {
+						found.add(variable);
+					}
+				}
 
-		const variables = [...new Set(nonUniquevariables)]
-		return createTrcRoot(variables, formula, proj)
+				// relAlias exists
+				if (typeof obj.relAlias === 'string') {
+					found.add(obj.relAlias);
+				}
+
+				// Special case: relAlias is null, but variable name seems to be used explicitly
+				if (
+					obj.relAlias === null &&
+					typeof obj.name === 'string' &&
+					['columnName', 'column'].includes(obj.type)
+				) {
+					found.add(obj.name);
+				}
+
+				// Run recursively over properties
+				for (const key in obj) {
+					if (obj.hasOwnProperty(key)) {
+						collectVariableNames(obj[key], found);
+					}
+				}
+			}
+
+			return found;
+		}
+
+		const uniqueVariables = Array.from(collectVariableNames(proj));
+		return createTrcRoot(uniqueVariables, formula, proj)
 	}
 
 Formula = LogicalExpression
@@ -484,6 +510,7 @@ valueExprFunctionsNary
 = func:(
 	('coalesce'i { return ['coalesce', 'null']; })
 	/ ('concat'i { return ['concat', 'string']; })
+	/ ('replace'i { return ['replace', 'string']; })
 )
 '(' _ arg0:valueExpr _ argn:(',' _ valueExpr _ )* ')'
 	{
@@ -502,8 +529,78 @@ valueExprFunctionsNary
 		};
 	}
 
-valueExprFunctionsBinary
+substringTernaryCommaStyle
 = func:(
+	('substring'i { return ['substring', 'string']; })
+)
+_ '(' _ arg0:valueExpr _ ',' _ arg1:valueExpr _ ',' _ arg2:valueExpr _ ')'
+	{
+		return {
+			type: 'valueExpr',
+			datatype: func[1],
+			func: func[0],
+			args: [arg0, arg1, arg2],
+
+			codeInfo: getCodeInfo()
+		};
+	}
+
+substringTernaryFromForStyle
+= func:(
+	('substring'i { return ['substring', 'string']; })
+)
+_ '(' _ arg0:valueExpr _ 'from'i _ arg1:valueExpr _ 'for'i _ arg2:valueExpr _ ')'
+	{
+		return {
+			type: 'valueExpr',
+			datatype: func[1],
+			func: func[0],
+			args: [arg0, arg1, arg2],
+
+			codeInfo: getCodeInfo()
+		};
+	}
+
+substringBinaryCommaStyle
+= func: (
+	('substring'i { return ['substring', 'string']; })
+)
+_ '(' _ arg0:valueExpr _ ',' _ arg1:valueExpr _ ')'
+	{
+		return {
+			type: 'valueExpr',
+			datatype: func[1],
+			func: func[0],
+			args: [arg0, arg1],
+
+			codeInfo: getCodeInfo()
+		};
+	}
+
+substringBinaryFromForStyle
+= func: (
+	('substring'i { return ['substring', 'string']; })
+)
+_ '(' _ arg0:valueExpr _ 'from'i _ arg1:valueExpr _ ')'
+	{
+		return {
+			type: 'valueExpr',
+			datatype: func[1],
+			func: func[0],
+			args: [arg0, arg1],
+
+			codeInfo: getCodeInfo()
+		};
+	}
+
+valueExprFunctionsTernary
+= substringTernaryCommaStyle
+/ substringTernaryFromForStyle
+
+valueExprFunctionsBinary
+= substringBinaryCommaStyle
+  / substringBinaryFromForStyle
+  / func:(
 	('adddate'i { return ['adddate', 'date']; })
 	/ ('subdate'i { return ['subdate', 'date']; })
 	/ ('mod'i { return ['mod', 'number']; })
@@ -511,6 +608,9 @@ valueExprFunctionsBinary
 	/ ('sub'i { return ['sub', 'number']; })
 	/ ('mul'i { return ['mul', 'number']; })
 	/ ('div'i { return ['div', 'number']; })
+	/ ('power'i { return ['power', 'number']; })
+	/ ('log'i { return ['log', 'number']; })
+	/ ('repeat'i { return ['repeat', 'string']; })
 )
 '(' _ arg0:valueExpr _ ',' _ arg1:valueExpr _ ')'
 	{
@@ -523,6 +623,25 @@ valueExprFunctionsBinary
 			codeInfo: getCodeInfo()
 		};
 	}
+/ func:(
+	('cast'i { return ['cast', 'null']; })
+)
+_ '(' _ arg0:valueExpr _ 'as'i _ arg1:('string'i / 'number'i / 'date'i / 'boolean'i) _ ')'
+	{
+		return {
+			type: 'valueExpr',
+			datatype: func[1],
+			func: func[0],
+			args: [arg0, {
+				datatype: 'string',
+				func: 'constant',
+				args: [arg1],
+				codeInfo: getCodeInfo()
+			}],
+
+			codeInfo: getCodeInfo()
+		};
+	}
 
 valueExprFunctionsUnary
 = func:(
@@ -530,14 +649,17 @@ valueExprFunctionsUnary
 	/ ('ucase'i { return ['upper', 'string']; })
 	/ ('lower'i { return ['lower', 'string']; })
 	/ ('lcase'i { return ['lower', 'string']; })
+	/ ('reverse'i { return ['reverse', 'string']; })
 	/ ('length'i { return ['strlen', 'number']; })
 	/ ('abs'i { return ['abs', 'number']; })
 	/ ('floor'i { return ['floor', 'number']; })
 	/ ('ceil'i { return ['ceil', 'number']; })
 	/ ('round'i { return ['round', 'number']; })
+	/ ('sqrt'i { return ['sqrt', 'number']; })
+	/ ('exp'i { return ['exp', 'number']; })
+	/ ('ln'i { return ['ln', 'number']; })
 
 	/ ('date'i { return ['date', 'date']; })
-
 	/ ('year'i { return ['year', 'number']; })
 	/ ('month'i { return ['month', 'number']; })
 	/ ('day'i { return ['dayofmonth', 'number']; })
@@ -546,7 +668,7 @@ valueExprFunctionsUnary
 	/ ('second'i { return ['second', 'number']; })
 	/ ('dayofmonth'i { return ['dayofmonth', 'number']; })
 )
-'(' _ arg0:valueExpr _ ')'
+_ '(' _ arg0:valueExpr _ ')'
 	{
 		return {
 			type: 'valueExpr',
@@ -572,7 +694,7 @@ valueExprFunctionsNullary
 	/ ('clock_timestamp'i { return ['clock_timestamp', 'date']; })
 	/ ('sysdate'i { return ['clock_timestamp', 'date']; })
 )
-'(' _ ')'
+_ '(' _ ')'
 	{
 		return {
 			type: 'valueExpr',
@@ -740,6 +862,7 @@ expr_precedence0
 / valueExprFunctionsNullary
 / valueExprFunctionsUnary
 / valueExprFunctionsBinary
+/ valueExprFunctionsTernary
 / valueExprFunctionsNary
 / valueExprColumn
 / '(' _ e:expr_precedence9 _ ')'
@@ -764,6 +887,16 @@ unqualifiedColumnName
 = !(RESERVED_KEYWORD !([0-9a-zA-Z_]+)) a:$([a-zA-Z]+ $[0-9a-zA-Z_]*)
 	{
 		return a;
+	}
+
+columnAsterisk
+= relAlias:(relationName '.')? '*'
+	{
+		return {
+			type: 'column',
+			name: '*',
+			relAlias: relAlias ? relAlias[0] : null
+		};
 	}
 
 columnName
@@ -816,6 +949,11 @@ namedColumnExpr
 / a:columnName
 	{
 		return a;
+	}
+/ col:columnAsterisk
+	{
+		col.alias = null;
+		return col;
 	}
 
 // list of columns (kd.id, kd.name, test) e.g. for the projection
@@ -903,12 +1041,13 @@ RESERVED_KEYWORDS_TRC
 RESERVED_KEYWORDS_FUNCTIONS
 = 'coalesce'i
 / 'concat'i
+/ 'cast'i
+/ 'substring'i
 / 'upper'i
 / 'ucase'i
 / 'lower'i
 / 'lcase'i
 / 'length'i
-/ 'strlen'i
 / 'like'i
 / 'ilike'i
 / 'rlike'i
@@ -924,6 +1063,11 @@ RESERVED_KEYWORDS_FUNCTIONS
 / 'div'i
 / 'mod'i
 / 'abs'i
+/ 'sqrt'i
+/ 'exp'i
+/ 'power'i
+/ 'ln'i
+/ 'log'i
 / 'round'i
 / 'floor'i
 / 'ceil'i

--- a/src/db/tests/translate_tests_trc.ts
+++ b/src/db/tests/translate_tests_trc.ts
@@ -74,22 +74,432 @@ QUnit.module('translate trc ast to relational algebra', () => {
 	});
 
 	QUnit.module('Projection', () => {
-		QUnit.test('test helper functions', (assert) => {
-			const queryTrc1 = '{ concat(t.b, t.c)->bla | R(t) }';
-			const queryTrc2 = '{ (t.b || t.c)->bla | R(t) }';
-			const queryRa = 'pi concat(b, c)->bla (R)'
 
-			const resultTrc1 = exec_trc(queryTrc1).getResult();
-			const resultTrc2 = exec_trc(queryTrc2).getResult();
-			const resultRa = exec_ra(queryRa).getResult();
+		QUnit.module('Helper functions', () => {
+			QUnit.test('test concat function', (assert) => {
+				const queryTrc1 = '{ concat(t.b, t.c)->bla | R(t) }';
+				const queryTrc2 = '{ (t.b || t.c)->bla | R(t) }';
+				const queryRa = 'pi concat(b, c)->bla (R)'
 
-			assert.deepEqual(resultTrc1.getRows(), resultRa.getRows());
-			assert.deepEqual(resultTrc2.getRows(), resultRa.getRows());
+				const resultTrc1 = exec_trc(queryTrc1).getResult();
+				const resultTrc2 = exec_trc(queryTrc2).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc1.getRows(), resultRa.getRows());
+				assert.deepEqual(resultTrc2.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test repeat function', function (assert) {
+				const queryTrc = "{ repeat(t.b, 3)->x | R(t) }";
+				const queryRa = " pi repeat(b, 3)->x (R) "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test replace function', (assert) => {
+				const queryTrc = "{ replace(concat(t.a, t.b, t.c), 'c', 'C')->bla | R(t) }";
+				const queryRa = " pi replace(x, 'c', 'C')->y (pi concat(a, b, c)->x (R)) "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test reverse function', (assert) => {
+				const queryTrc = "{ reverse(concat(t.a, t.b, t.c))->x | R(t) }";
+				const queryRa = " pi reverse(x)->y (pi concat(a, b, c)->x (R)) "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test sqrt negative number', function (assert) {
+				const queryTrc = "{ t.a, sqrt(-4)->k | R(t) }";
+				const queryRa = " pi a, sqrt(-4)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test sqrt of negative number', function (assert) {
+				const queryTrc = "{ t.a, sqrt(-4)->k | R(t) }";
+				const queryRa = " pi a, sqrt(-4)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test sqrt of zero', function (assert) {
+				const queryTrc = "{ t.a, sqrt(0)->k | R(t) }";
+				const queryRa = " pi a, sqrt(0)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test sqrt of one', function (assert) {
+				const queryTrc = "{ t.a, sqrt(1)->k | R(t) }";
+				const queryRa = " pi a, sqrt(1)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test sqrt of one hundred', function (assert) {
+				const queryTrc = "{ t.a, sqrt(100)->k | R(t) }";
+				const queryRa = " pi a, sqrt(100)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test e raised to the power of 0', function (assert) {
+				const queryTrc = "{ t.a, exp(0)->k | R(t) }";
+				const queryRa = " pi a, exp(0)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test e raised to the power of 1', function (assert) {
+				const queryTrc = "{ t.a, exp(1)->k | R(t) }";
+				const queryRa = " pi a, exp(1)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test e raised to the power of 2', function (assert) {
+				const queryTrc = "{ t.a, exp(2)->k | R(t) }";
+				const queryRa = " pi a, exp(2)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test column raised to the power of 0', function (assert) {
+				const queryTrc = "{ t.a, power(a, 0)->k | R(t) }";
+				const queryRa = " pi a, power(a, 0)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test column raised to the power of 1', function (assert) {
+				const queryTrc = "{ t.a, power(a, 1)->k | R(t) }";
+				const queryRa = " pi a, power(a, 1)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test column raised to the power of 2', function (assert) {
+				const queryTrc = "{ t.a, power(a, 2)->k | R(t) }";
+				const queryRa = " pi a, power(a, 2)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test natural logarithm of a negative number', function (assert) {
+				const queryTrc = "{ t.a, ln(-1)->k | R(t) }";
+				const queryRa = " pi a, ln(-1)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test natural logarithm of zero', function (assert) {
+				const queryTrc = "{ t.a, ln(0)->k | R(t) }";
+				const queryRa = " pi a, ln(0)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test natural logarithm of 1', function (assert) {
+				const queryTrc = "{ t.a, ln(1)->k | R(t) }";
+				const queryRa = " pi a, ln(1)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test natural logarithm of 2', function (assert) {
+				const queryTrc = "{ t.a, ln(2)->k | R(t) }";
+				const queryRa = " pi a, ln(2)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test logarithm, base 2, of -1', function (assert) {
+				const queryTrc = "{ t.a, log(2, -1)->k | R(t) }";
+				const queryRa = " pi a, log(2, -1)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test logarithm, base 2, of 0', function (assert) {
+				const queryTrc = "{ t.a, log(2, 0)->k | R(t) }";
+				const queryRa = " pi a, log(2, 0)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test logarithm, base 2, of 1', function (assert) {
+				const queryTrc = "{ t.a, log(2, 1)->k | R(t) }";
+				const queryRa = " pi a, log(2, 1)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test logarithm, base -1, of 16', function (assert) {
+				const queryTrc = "{ t.a, log(-1, 16)->k | R(t) }";
+				const queryRa = " pi a, log(-1, 16)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test logarithm, base 0, of 16', function (assert) {
+				const queryTrc = "{ t.a, log(0, 16)->k | R(t) }";
+				const queryRa = " pi a, log(0, 16)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test logarithm, base 1, of 16', function (assert) {
+				const queryTrc = "{ t.a, log(1, 16)->k | R(t) }";
+				const queryRa = " pi a, log(1, 16)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test logarithm, base 2, of 4', function (assert) {
+				const queryTrc = "{ t.a, log(2, 4)->k | R(t) }";
+				const queryRa = " pi a, log(2, 4)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test logarithm, base 10, of 1000', function (assert) {
+				const queryTrc = "{ t.a, log(10, 1000)->k | R(t) }";
+				const queryRa = " pi a, log(10, 1000)->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 2 args comma style', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('Quadratically',5) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('Quadratically',5) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 2 args from style', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('foobarbar' FROM 4) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('foobarbar' FROM 4) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 2 args negative pos', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('Sakila', -3) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('Sakila', -3) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 3 args comma style', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('Quadratically',5,6) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('Quadratically',5,6) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 3 args from/for style', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('Quadratically' FROM 5 for 6) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('Quadratically' FROM 5 for 6) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 3 args negative pos', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('Sakila', -5, 3) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('Sakila', -5, 3) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 3 args pos equals to 0', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('abcdef', 0, 5) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('abcdef', 0, 5) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 3 args pos greater than string length', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('abcdef', 100, 5) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('abcdef', 100, 5) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 3 args negative length', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('abcdef', 5, -3) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('abcdef', 5, -3) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 3 args length equals to 0', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('abcdef', 5, 0) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('abcdef', 5, 0) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test substring 3 args length greater than string length', function (assert) {
+				const queryTrc = "{ t.a, SUBSTRING('abcdef', 5, 10) -> str | R(t) }";
+				const queryRa = " pi a, SUBSTRING('abcdef', 5, 10) -> str R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test cast function', function (assert) {
+				const queryTrc = "{ cast(t.a as string) -> str, cast('100' as number)->n , cast('false' as boolean) -> bool, cast('2025-04-16' as date)->dt | t in R }";
+				const queryRa = " pi cast(a as string) -> str, cast('100' as number)->n , cast('false' as boolean) -> bool, cast('2025-04-16' as date)->dt R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test combined functions v1', function (assert) {
+				const queryTrc = "{ length(concat(t.a, t.b, t.c))->k | t in R }";
+				const queryRa = " pi length(concat(t.a, t.b, t.c))->k R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
+
+			QUnit.test('test combined functions v2', function (assert) {
+				const queryTrc = "{ t.a, (concat('tam=', length(concat(t.a,t.b,t.c))))->n | t in R }";
+				const queryRa = " pi a, (concat('tam=', length(concat(t.a,t.b,t.c))))->n R "
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc.getRows(), resultRa.getRows());
+			});
 		});
 
 		QUnit.module('Single tuple variable', () => {
 			QUnit.test('test project all columns', (assert) => {
 				const query = '{ t | R(t) }';
+				const root = exec_trc(query);
+
+				assert.deepEqual(root.getResult().getRows(), srcTableR.getResult().getRows());
+			});
+
+			QUnit.test('test project all columns (asterisk)', (assert) => {
+				const query = '{ t.* | R(t) }';
 				const root = exec_trc(query);
 
 				assert.deepEqual(root.getResult().getRows(), srcTableR.getResult().getRows());
@@ -138,11 +548,51 @@ QUnit.module('translate trc ast to relational algebra', () => {
 
 				assert.deepEqual(resultRa, resultTrc);
 			});
+
+			QUnit.test('test project constant', (assert) => {
+				const queryTrc = '{ 1->c | R(r) }';
+				const queryRa = 'pi 1->c (R)';
+
+				const resultTrc = exec_trc(queryTrc).getResult().getRows();
+				const resultRa = exec_ra(queryRa).getResult().getRows();
+
+				assert.deepEqual(resultRa, resultTrc);
+			});
 		});
 
 		QUnit.module('Multiple tuple variables', () => {
 			QUnit.test('test project all columns', (assert) => {
 				const queryTrc = '{ t, p | R(t) and S(p) }';
+				const queryRa = 'ρ t R ⨯ ρ p S'
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc, resultRa);
+			});
+
+			QUnit.test('test project all columns (asterik v1)', (assert) => {
+				const queryTrc = '{ t.*, p | R(t) and S(p) }';
+				const queryRa = 'ρ t R ⨯ ρ p S'
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc, resultRa);
+			});
+
+			QUnit.test('test project all columns (asterik v2)', (assert) => {
+				const queryTrc = '{ t, p.* | R(t) and S(p) }';
+				const queryRa = 'ρ t R ⨯ ρ p S'
+
+				const resultTrc = exec_trc(queryTrc).getResult();
+				const resultRa = exec_ra(queryRa).getResult();
+
+				assert.deepEqual(resultTrc, resultRa);
+			});
+
+			QUnit.test('test project all columns (asterik v3)', (assert) => {
+				const queryTrc = '{ t.*, p.* | R(t) and S(p) }';
 				const queryRa = 'ρ t R ⨯ ρ p S'
 
 				const resultTrc = exec_trc(queryTrc).getResult();


### PR DESCRIPTION
# Reference issue

https://github.com/dbis-uibk/relax/issues/243

# What does this implement/fix?

This PR brings a bug fix and also enhancements to the TRC implementation. The changes can be summarized as follows:

- Fix https://github.com/dbis-uibk/relax/issues/243;
- Support asterisk projection of tuple variables, i.e., `{ t.* | R(t) }`;
- Support projection of constants only (without fields of tuple variable), i.e., `{ 1->n | t in R }`;
- Add missing valueExpr functions (i.e., repeat, replace, reverse, substring, exp, power, ln, log, sqrt, cast);
- Add unit tests;
