### PR TITLE
Fixes and enhancements in operator replacement (RA and Bags)

### DIFF
--- a/src/db/parser/grammar_bags.pegjs
+++ b/src/db/parser/grammar_bags.pegjs
@@ -303,15 +303,27 @@ rho
 
 arrowLeft
 = _ o:('←' { return getNodeInfo('arrowLeft'); }) _
-	{ return o; }
+	{
+		operatorPositions.push(o);
+		return o;
+	}
 / _ o:('<-' { return getNodeInfo('arrowLeft'); }) _
-	{ return o; }
+	{
+		operatorPositions.push(o);
+		return o;
+	}
 
 arrowRight
 = _ o:('→' { return getNodeInfo('arrowRight'); }) _
-	{ return o; }
+	{
+		operatorPositions.push(o);
+		return o;
+	}
 / _ o:('->' { return getNodeInfo('arrowRight'); }) _
-	{ return o; }
+	{ 
+		operatorPositions.push(o);
+		return o;
+	}
 
 psi
 = _ o:('ψ' { return getNodeInfo('psi'); }) _
@@ -1116,48 +1128,80 @@ comparisonOperatorEquals
 = '='
 
 comparisonOperatorNotEquals
-= ('!=' / '≠' / '<>')
-	{ return '!='; }
+= _ co:('!=' { return getNodeInfo('notEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '!=';
+	}
+/ _ co:('≠' { return getNodeInfo('notEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '!=';
+	}
+/ _ co:('<>' { return getNodeInfo('notEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '!=';
+	}
 
 comparisonOperatorGreaterEquals
-= ('>=' / '≥')
-	{ return '>='; }
+= _ co:('>=' { return getNodeInfo('GreaterThanOrEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '>=';
+	}
+/ _ co:('≥' { return getNodeInfo('GreaterThanOrEquals'); })
+	{
+		operatorPositions.push(co);
+		return '>=';
+	}
 
 comparisonOperatorGreater
 = '>'
 
 comparisonOperatorLesserEquals
-= ('<=' / '≤')
-	{ return '<='; }
+= _ co:('<=' { return getNodeInfo('LessThanOrEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '<=';
+	}
+/ _ co:('≤' { return getNodeInfo('LessThanOrEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '<=';
+	}
 
 comparisonOperatorLesser
 = '<'
 
 and 'logical AND'
-= __ 'and'i __
-/ _ '∧' _
+= __ lo:('and'i { return getNodeInfo('and'); }) __
+	{ return lo; }
+/ _ lo:('∧' { return getNodeInfo('and'); }) _
+	{ return lo; }
 
 xor 'logical XOR'
-= __ 'xor'i __
-/ _ ('⊻' / '⊕') _
+= __ lo:('xor'i { return getNodeInfo('xor'); }) __
+	{ return lo; }
+/ _ lo:('⊻' { return getNodeInfo('xor'); }) _
+	{ return lo; }
 
 or 'logical OR'
-= __ 'or'i __
-/ _ '∨' _
+= __ lo:('or'i { return getNodeInfo('or'); }) __
+	{ return lo; }
+/ _ lo:('∨' { return getNodeInfo('or'); }) _
+	{ return lo; }
 
 not 'logical NOT'
-= _ ('!' / '¬') _
+= _ lo:('!' { return getNodeInfo('not'); }) _
+	{ return lo; }
+/ _ lo:('¬' { return getNodeInfo('not'); }) _
+	{ return lo; }
+/ _ lo:('not'i { return getNodeInfo('not'); }) _
+	{ return lo; }
 
 
-
-
-
-
-
-/* this is a syntax for a constant table
-
-
-*/
+/* this is a syntax for a constant table */
 
 tableDelimiter 'delimiter'
 = _sl ',' _sl
@@ -1401,8 +1445,9 @@ booleanExpr 'boolean expression'
 = valueExpr
 
 expr_rest_boolean_disj
-= or right:expr_precedence8
+= lo:or right:expr_precedence8
 	{
+		operatorPositions.push(lo);
 		return {
 			type: 'valueExpr',
 			datatype: 'boolean',
@@ -1427,8 +1472,9 @@ expr_rest_string_concat
 	}
 
 expr_rest_boolean_xdisj
-= xor right:expr_precedence7
+= lo:xor right:expr_precedence7
 	{
+		operatorPositions.push(lo);
 		return {
 			type: 'valueExpr',
 			datatype: 'boolean',
@@ -1440,8 +1486,9 @@ expr_rest_boolean_xdisj
 	}
 
 expr_rest_boolean_conj
-= and right:expr_precedence6
+= lo:and right:expr_precedence6
 	{
+		operatorPositions.push(lo);
 		return {
 			type: 'valueExpr',
 			datatype: 'boolean',
@@ -1547,8 +1594,9 @@ expr_number_minus
 	}
 
 expr_boolean_negation
-= not a:expr_precedence0
+= lo:not a:expr_precedence0
 	{
+		operatorPositions.push(lo);
 		return {
 			type: 'valueExpr',
 			datatype: 'boolean',

--- a/src/db/parser/grammar_ra.pegjs
+++ b/src/db/parser/grammar_ra.pegjs
@@ -297,15 +297,27 @@ rho
 
 arrowLeft
 = _ o:('←' { return getNodeInfo('arrowLeft'); }) _
-	{ return o; }
+	{
+		operatorPositions.push(o);
+		return o;
+	}
 / _ o:('<-' { return getNodeInfo('arrowLeft'); }) _
-	{ return o; }
+	{
+		operatorPositions.push(o);
+		return o;
+	}
 
 arrowRight
 = _ o:('→' { return getNodeInfo('arrowRight'); }) _
-	{ return o; }
+	{
+		operatorPositions.push(o);
+		return o;
+	}
 / _ o:('->' { return getNodeInfo('arrowRight'); }) _
-	{ return o; }
+	{ 
+		operatorPositions.push(o);
+		return o;
+	}
 
 psi
 = _ o:('ψ' { return getNodeInfo('psi'); }) _
@@ -1099,48 +1111,80 @@ comparisonOperatorEquals
 = '='
 
 comparisonOperatorNotEquals
-= ('!=' / '≠' / '<>')
-	{ return '!='; }
+= _ co:('!=' { return getNodeInfo('notEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '!=';
+	}
+/ _ co:('≠' { return getNodeInfo('notEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '!=';
+	}
+/ _ co:('<>' { return getNodeInfo('notEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '!=';
+	}
 
 comparisonOperatorGreaterEquals
-= ('>=' / '≥')
-	{ return '>='; }
+= _ co:('>=' { return getNodeInfo('GreaterThanOrEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '>=';
+	}
+/ _ co:('≥' { return getNodeInfo('GreaterThanOrEquals'); })
+	{
+		operatorPositions.push(co);
+		return '>=';
+	}
 
 comparisonOperatorGreater
 = '>'
 
 comparisonOperatorLesserEquals
-= ('<=' / '≤')
-	{ return '<='; }
+= _ co:('<=' { return getNodeInfo('LessThanOrEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '<=';
+	}
+/ _ co:('≤' { return getNodeInfo('LessThanOrEquals'); }) _
+	{
+		operatorPositions.push(co);
+		return '<=';
+	}
 
 comparisonOperatorLesser
 = '<'
 
 and 'logical AND'
-= __ 'and'i __
-/ _ '∧' _
+= __ lo:('and'i { return getNodeInfo('and'); }) __
+	{ return lo; }
+/ _ lo:('∧' { return getNodeInfo('and'); }) _
+	{ return lo; }
 
 xor 'logical XOR'
-= __ 'xor'i __
-/ _ ('⊻' / '⊕') _
+= __ lo:('xor'i { return getNodeInfo('xor'); }) __
+	{ return lo; }
+/ _ lo:('⊻' { return getNodeInfo('xor'); }) _
+	{ return lo; }
 
 or 'logical OR'
-= __ 'or'i __
-/ _ '∨' _
+= __ lo:('or'i { return getNodeInfo('or'); }) __
+	{ return lo; }
+/ _ lo:('∨' { return getNodeInfo('or'); }) _
+	{ return lo; }
 
 not 'logical NOT'
-= _ ('!' / '¬') _
+= _ lo:('!' { return getNodeInfo('not'); }) _
+	{ return lo; }
+/ _ lo:('¬' { return getNodeInfo('not'); }) _
+	{ return lo; }
+/ _ lo:('not'i { return getNodeInfo('not'); }) _
+	{ return lo; }
 
 
-
-
-
-
-
-/* this is a syntax for a constant table
-
-
-*/
+/* this is a syntax for a constant table */
 
 tableDelimiter 'delimiter'
 = _sl ',' _sl
@@ -1384,8 +1428,9 @@ booleanExpr 'boolean expression'
 = valueExpr
 
 expr_rest_boolean_disj
-= or right:expr_precedence8
+= lo:or right:expr_precedence8
 	{
+		operatorPositions.push(lo);
 		return {
 			type: 'valueExpr',
 			datatype: 'boolean',
@@ -1410,8 +1455,9 @@ expr_rest_string_concat
 	}
 
 expr_rest_boolean_xdisj
-= xor right:expr_precedence7
+= lo:xor right:expr_precedence7
 	{
+		operatorPositions.push(lo);
 		return {
 			type: 'valueExpr',
 			datatype: 'boolean',
@@ -1423,8 +1469,9 @@ expr_rest_boolean_xdisj
 	}
 
 expr_rest_boolean_conj
-= and right:expr_precedence6
+= lo:and right:expr_precedence6
 	{
+		operatorPositions.push(lo);
 		return {
 			type: 'valueExpr',
 			datatype: 'boolean',
@@ -1530,8 +1577,9 @@ expr_number_minus
 	}
 
 expr_boolean_negation
-= not a:expr_precedence0
+= lo:not a:expr_precedence0
 	{
+		operatorPositions.push(lo);
 		return {
 			type: 'valueExpr',
 			datatype: 'boolean',

--- a/src/db/relalg.ts
+++ b/src/db/relalg.ts
@@ -50,10 +50,17 @@ export function queryWithReplacedOperatorsFromAst(
 			'psi': 'psi',
 			'tau': 'tau',
 			'gamma': 'gamma',
+			'and': 'and',
+			'xor': 'xor',
+			'or': 'or',
+			'not': '!',
+			'notEquals': '!=',
+			'LessThanOrEquals': '<=',
+			'GreaterThanOrEquals': '>=',
 			'unionOperator': 'union',
 			'intersectOperator': 'intersect',
 			'divisionOperator': '/',
-			'differenceOperator': '-',
+			'differenceOperator': 'except',
 			'crossJoinOperator': 'cross join',
 			'innerJoinOperator': 'inner join',
 			'naturalJoinOperator': 'natural join',
@@ -74,6 +81,13 @@ export function queryWithReplacedOperatorsFromAst(
 			'psi': 'ψ',
 			'tau': 'τ',
 			'gamma': 'γ',
+			'and': '∧',
+			'xor': '⊻',
+			'or': '∨',
+			'not': '¬',
+			'notEquals': '≠',
+			'LessThanOrEquals': '≤',
+			'GreaterThanOrEquals': '≥',
 			'unionOperator': '∪',
 			'intersectOperator': '∩',
 			'divisionOperator': '÷',
@@ -89,10 +103,24 @@ export function queryWithReplacedOperatorsFromAst(
 			'fullOuterJoinOperator': '⟗',
 		},
 	};
+
+	// sort operator positions by line and column (descending order)
+	// this is important because we need to replace the farthest operator first
+	operatorPositions.sort(
+		(a, b) =>
+			a.location.start.line > b.location.start.line ?
+				1 : 
+				(
+					a.location.start.line === b.location.start.line &&
+					a.location.start.column > b.location.start.column ?
+					1 : -1
+				)
+	);
+
 	for (let i = operatorPositions.length - 1; i >= 0; i--) {
 		const op = operatorPositions[i];
 		const location = op.location; // = location without surrounding whitespace
-		const left = query.substr(0, location.start.offset - 1); // fixed offset | #174
+		const left = query.substr(0, location.start.offset); // fixed offset | #174
 		const right = query.substring(location.end.offset);
 		const newOperator = (newOperators[mode] as any)[op.name]; // TODO: fix typings
 		const oldOperator = query.substring(location.start.offset, location.end.offset);
@@ -157,11 +185,9 @@ export function queryWithReplacedTRCOperatorsFromAst(
 			'⊻': 'xor',
 			'∨': 'or',
 			'¬': 'not',
-			'!': 'not',
 			'⇒': '=>',
 			'⇔': '<=>',
 			'≠': '!=',
-			'<>': '!=',
 			'≤': '<=',
 			'≥': '>=',
 			'∃': 'exists',

--- a/src/db/tests/var_replacer_tests.ts
+++ b/src/db/tests/var_replacer_tests.ts
@@ -623,3 +623,593 @@ QUnit.test('replace operators 3', function (assert) {
 	assert.equal(query, `π a R ⨝ S`);
 	assert.deepEqual(cursor, { line: 1, column: 8 });
 });
+
+QUnit.test('replace operators 4 (#174)', function (assert) {
+	const orgQuery = `pi b (sigma a=0 R)`;
+	const orgCursor = { line: 1, column: 12 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `π b (σ a=0 R)`);
+	assert.deepEqual(cursor, { line: 1, column: 7 });
+});
+
+QUnit.test('replace rename relation operator (plain2math)', function (assert) {
+	const orgQuery = `rho R_prime  (R)`;
+	const orgCursor = { line: 1, column: 12 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `ρ R_prime  (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 10 });
+});
+
+QUnit.test('replace rename relation operator (math2plain)', function (assert) {
+	const orgQuery = `ρ  R_prime (R)`;
+	const orgCursor = { line: 1, column: 11 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `rho  R_prime (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 13 });
+});
+
+QUnit.test('replace rename column operator (plain2math)', function (assert) {
+	const orgQuery = `rho a ->A (R)`;
+	const orgCursor = { line: 1, column: 9 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `ρ a →A (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace rename column operator (math2plain)', function (assert) {
+	const orgQuery = `ρ a-> A (R)`;
+	const orgCursor = { line: 1, column: 8 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `rho a-> A (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 10 });
+});
+
+QUnit.test('replace order by operator (plain2math)', function (assert) {
+	const orgQuery = `tau a desc R`;
+	const orgCursor = { line: 1, column: 6 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `τ a desc R`);
+	assert.deepEqual(cursor, { line: 1, column: 4 });
+});
+
+QUnit.test('replace order by operator (math2plain)', function (assert) {
+	const orgQuery = `τ a desc R`;
+	const orgCursor = { line: 1, column: 4 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `tau a desc R`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace group by operator (plain2math)', function (assert) {
+	const orgQuery = `gamma b; count(*)->n (R)`;
+	const orgCursor = { line: 1, column: 20 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `γ b; count(*)→n (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 15 });
+});
+
+QUnit.test('replace group by operator (math2plain)', function (assert) {
+	const orgQuery = `γ b; count(*)→n (R)`;
+	const orgCursor = { line: 1, column: 15 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `gamma b; count(*)->n (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 20 });
+});
+
+QUnit.test('replace union operator (plain2math)', function (assert) {
+	const orgQuery = `S  union   T`;
+	const orgCursor = { line: 1, column: 10 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `S  ∪   T`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace union operator (math2plain)', function (assert) {
+	const orgQuery = `S   ∪  T`;
+	const orgCursor = { line: 1, column: 6 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `S   union  T`);
+	assert.deepEqual(cursor, { line: 1, column: 10 });
+});
+
+QUnit.test('replace intersect operator (plain2math)', function (assert) {
+	const orgQuery = `S  intersect   T`;
+	const orgCursor = { line: 1, column: 14 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `S  ∩   T`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace intersect operator (math2plain)', function (assert) {
+	const orgQuery = `S   ∩  T`;
+	const orgCursor = { line: 1, column: 8 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `S   intersect  T`);
+	assert.deepEqual(cursor, { line: 1, column: 16 });
+});
+
+QUnit.test('replace except operator (plain2math)', function (assert) {
+	const orgQuery = `S  except   T`;
+	const orgCursor = { line: 1, column: 14 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `S  -   T`);
+	assert.deepEqual(cursor, { line: 1, column: 9 });
+});
+
+QUnit.test('replace except operator (math2plain)', function (assert) {
+	const orgQuery = `S   -  T`;
+	const orgCursor = { line: 1, column: 8 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `S   except  T`);
+	assert.deepEqual(cursor, { line: 1, column: 13 });
+});
+
+QUnit.test('replace division operator (plain2math)', function (assert) {
+	const orgQuery = `S  /   T`;
+	const orgCursor = { line: 1, column: 9 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `S  ÷   T`);
+	assert.deepEqual(cursor, { line: 1, column: 9 });
+});
+
+QUnit.test('replace division operator (math2plain)', function (assert) {
+	const orgQuery = `S   ÷  T`;
+	const orgCursor = { line: 1, column: 8 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `S   /  T`);
+	assert.deepEqual(cursor, { line: 1, column: 8 });
+});
+
+QUnit.test('replace natural join operator (plain2math)', function (assert) {
+	const orgQuery = `R  natural join S`;
+	const orgCursor = { line: 1, column: 16 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⨝ S`);
+	assert.deepEqual(cursor, { line: 1, column: 5 });
+});
+
+QUnit.test('replace natural join operator (math2plain)', function (assert) {
+	const orgQuery = `R ⨝  S`;
+	const orgCursor = { line: 1, column: 6 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R natural join  S`);
+	assert.deepEqual(cursor, { line: 1, column: 17 });
+});
+
+QUnit.test('replace theta join operator (plain2math)', function (assert) {
+	const orgQuery = `R join  R.b = S.b S`;
+	const orgCursor = { line: 1, column: 13 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R ⨝  R.b = S.b S`);
+	assert.deepEqual(cursor, { line: 1, column: 10 });
+});
+
+QUnit.test('replace theta join operator (math2plain)', function (assert) {
+	const orgQuery = `R  ⨝  R.b = S.b   S`;
+	const orgCursor = { line: 1, column: 9 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R  inner join  R.b = S.b   S`);
+	assert.deepEqual(cursor, { line: 1, column: 18 });
+});
+
+QUnit.test('replace natural left outer join operator (plain2math)', function (assert) {
+	const orgQuery = `R  left outer join S`;
+	const orgCursor = { line: 1, column: 19 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⟕ S`);
+	assert.deepEqual(cursor, { line: 1, column: 5 });
+});
+
+QUnit.test('replace natural left outer join operator (math2plain)', function (assert) {
+	const orgQuery = `R  ⟕  S`;
+	const orgCursor = { line: 1, column: 6 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R  left outer join  S`);
+	assert.deepEqual(cursor, { line: 1, column: 20 });
+});
+
+QUnit.test('replace theta left outer join operator (plain2math)', function (assert) {
+	const orgQuery = `R  left outer join  R.b =   S.b S`;
+	const orgCursor = { line: 1, column: 29 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⟕  R.b =   S.b S`);
+	assert.deepEqual(cursor, { line: 1, column: 15 });
+});
+
+QUnit.test('replace theta left outer join operator (math2plain)', function (assert) {
+	const orgQuery = `R ⟕  R.b  = S.b S`;
+	const orgCursor = { line: 1, column: 12 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R left outer join  R.b  = S.b S`);
+	assert.deepEqual(cursor, { line: 1, column: 26 });
+});
+
+QUnit.test('replace natural right outer join operator (plain2math)', function (assert) {
+	const orgQuery = `R  right outer join S`;
+	const orgCursor = { line: 1, column: 21 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⟖ S`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace natural right outer join operator (math2plain)', function (assert) {
+	const orgQuery = `R  ⟖  S`;
+	const orgCursor = { line: 1, column: 7 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R  right outer join  S`);
+	assert.deepEqual(cursor, { line: 1, column: 22 });
+});
+
+QUnit.test('replace theta right outer join operator (plain2math)', function (assert) {
+	const orgQuery = `R  right outer join  R.b =   S.b S`;
+	const orgCursor = { line: 1, column: 29 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⟖  R.b =   S.b S`);
+	assert.deepEqual(cursor, { line: 1, column: 14 });
+});
+
+QUnit.test('replace theta right outer join operator (math2plain)', function (assert) {
+	const orgQuery = `R ⟖  R.b  = S.b S`;
+	const orgCursor = { line: 1, column: 12 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R right outer join  R.b  = S.b S`);
+	assert.deepEqual(cursor, { line: 1, column: 27 });
+});
+
+QUnit.test('replace natural full outer join operator (plain2math)', function (assert) {
+	const orgQuery = `R  full outer join S`;
+	const orgCursor = { line: 1, column: 21 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⟗ S`);
+	assert.deepEqual(cursor, { line: 1, column: 7 });
+});
+
+QUnit.test('replace natural full outer join operator (math2plain)', function (assert) {
+	const orgQuery = `R  ⟗  S`;
+	const orgCursor = { line: 1, column: 7 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R  full outer join  S`);
+	assert.deepEqual(cursor, { line: 1, column: 21 });
+});
+
+QUnit.test('replace theta full outer join operator (plain2math)', function (assert) {
+	const orgQuery = `R  full outer join  R.b =   S.b S`;
+	const orgCursor = { line: 1, column: 29 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⟗  R.b =   S.b S`);
+	assert.deepEqual(cursor, { line: 1, column: 15 });
+});
+
+QUnit.test('replace theta full outer join operator (math2plain)', function (assert) {
+	const orgQuery = `R ⟗  R.b  = S.b S`;
+	const orgCursor = { line: 1, column: 12 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R full outer join  R.b  = S.b S`);
+	assert.deepEqual(cursor, { line: 1, column: 26 });
+});
+
+QUnit.test('replace natural left semi join operator (plain2math)', function (assert) {
+	const orgQuery = `R  left semi join S`;
+	const orgCursor = { line: 1, column: 19 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⋉ S`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace natural left semi join operator (math2plain)', function (assert) {
+	const orgQuery = `R  ⋉  S`;
+	const orgCursor = { line: 1, column: 7 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R  left semi join  S`);
+	assert.deepEqual(cursor, { line: 1, column: 20 });
+});
+
+QUnit.test('replace natural right semi join operator (plain2math)', function (assert) {
+	const orgQuery = `R  right semi join S`;
+	const orgCursor = { line: 1, column: 19 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `R  ⋊ S`);
+	assert.deepEqual(cursor, { line: 1, column: 5 });
+});
+
+QUnit.test('replace natural right semi join operator (math2plain)', function (assert) {
+	const orgQuery = `R  ⋊  S`;
+	const orgCursor = { line: 1, column: 7 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `R  right semi join  S`);
+	assert.deepEqual(cursor, { line: 1, column: 21 });
+});
+
+QUnit.test('replace natural anti join operator (plain2math)', function (assert) {
+	const orgQuery = `S  anti join R`;
+	const orgCursor = { line: 1, column: 14 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `S  ▷ R`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace natural anti join operator (math2plain)', function (assert) {
+	const orgQuery = `S  ▷  R`;
+	const orgCursor = { line: 1, column: 7 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `S  anti join  R`);
+	assert.deepEqual(cursor, { line: 1, column: 15 });
+});
+
+QUnit.test('replace rename column operator (->)', function (assert) {
+	const orgQuery = `pi a->A (R)`;
+	const orgCursor = { line: 1, column: 7 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `π a→A (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 5 });
+});
+
+QUnit.test('replace rename column operator (→)', function (assert) {
+	const orgQuery = `π a→A (R)`;
+	const orgCursor = { line: 1, column: 6 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `pi a->A (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 8 });
+});
+
+QUnit.test('replace rename column operator (<-)', function (assert) {
+	const orgQuery = `pi A<-a (R)`;
+	const orgCursor = { line: 1, column: 5 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `π A←a (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 4 });
+});
+
+QUnit.test('replace rename column operator (←)', function (assert) {
+	const orgQuery = `π A←a (R)`;
+	const orgCursor = { line: 1, column: 5 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `pi A<-a (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 7 });
+});
+
+QUnit.test('replace logical operator (and)', function (assert) {
+	const orgQuery = `sigma a > 2 and a < 4 R`;
+	const orgCursor = { line: 1, column: 12 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ a > 2 ∧ a < 4 R`);
+	assert.deepEqual(cursor, { line: 1, column: 8 });
+});
+
+QUnit.test('replace logical operator (∧)', function (assert) {
+	const orgQuery = `σ a > 2 ∧ a < 4 R`;
+	const orgCursor = { line: 1, column: 10 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `sigma a > 2 and a < 4 R`);
+	assert.deepEqual(cursor, { line: 1, column: 16 });
+});
+
+QUnit.test('replace logical operator (or)', function (assert) {
+	const orgQuery = `sigma a > 2 or a < 4 R`;
+	const orgCursor = { line: 1, column: 9 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ a > 2 ∨ a < 4 R`);
+	assert.deepEqual(cursor, { line: 1, column: 5 });
+});
+
+QUnit.test('replace logical operator (∨)', function (assert) {
+	const orgQuery = `σ a > 2 ∨ a < 4 R`;
+	const orgCursor = { line: 1, column: 12 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `sigma a > 2 or a < 4 R`);
+	assert.deepEqual(cursor, { line: 1, column: 17 });
+});
+
+QUnit.test('replace logical operator (xor)', function (assert) {
+	const orgQuery = `sigma a > 2 xor a < 4 R`;
+	const orgCursor = { line: 1, column: 13 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ a > 2 ⊻ a < 4 R`);
+	assert.deepEqual(cursor, { line: 1, column: 9 });
+});
+
+QUnit.test('replace logical operator (⊻)', function (assert) {
+	const orgQuery = `σ a > 2 ⊻ a < 4 R`;
+	const orgCursor = { line: 1, column: 10 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `sigma a > 2 xor a < 4 R`);
+	assert.deepEqual(cursor, { line: 1, column: 16 });
+});
+
+QUnit.test('replace logical operator (!)', function (assert) {
+	const orgQuery = `sigma !(a > 3) R`;
+	const orgCursor = { line: 1, column: 15 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ ¬(a > 3) R`);
+	assert.deepEqual(cursor, { line: 1, column: 11 });
+});
+
+QUnit.test('replace logical operator (not)', function (assert) {
+	const orgQuery = `sigma not(a > 3) R`;
+	const orgCursor = { line: 1, column: 10 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ ¬(a > 3) R`);
+	assert.deepEqual(cursor, { line: 1, column: 4 });
+});
+
+QUnit.test('replace logical operator (¬)', function (assert) {
+	const orgQuery = `σ ¬(a > 3) R`;
+	const orgCursor = { line: 1, column: 7 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `sigma !(a > 3) R`);
+	assert.deepEqual(cursor, { line: 1, column: 11 });
+});
+
+QUnit.test('replace comparison operator (!=)', function (assert) {
+	const orgQuery = `sigma a != 5 (R)`;
+	const orgCursor = { line: 1, column: 11 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ a ≠ 5 (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace comparison operator (<>)', function (assert) {
+	const orgQuery = `sigma a <> 5 (R)`;
+	const orgCursor = { line: 1, column: 11 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ a ≠ 5 (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 6 });
+});
+
+QUnit.test('replace comparison operator (≠)', function (assert) {
+	const orgQuery = `σ a ≠ 5 (R)`;
+	const orgCursor = { line: 1, column: 6 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `sigma a != 5 (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 11 });
+});
+
+QUnit.test('replace comparison operator (>=)', function (assert) {
+	const orgQuery = `sigma a >=3 (R)`;
+	const orgCursor = { line: 1, column: 12 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ a ≥3 (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 7 });
+});
+
+QUnit.test('replace comparison operator (≥)', function (assert) {
+	const orgQuery = `σ a ≥3 (R)`;
+	const orgCursor = { line: 1, column: 7 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `sigma a >=3 (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 12 });
+});
+
+QUnit.test('replace comparison operator (<=)', function (assert) {
+	const orgQuery = `sigma a<= 4 (R)`;
+	const orgCursor = { line: 1, column: 10 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'plain2math');
+	assert.equal(query, `σ a≤ 4 (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 5 });
+});
+
+QUnit.test('replace comparison operator (≥)', function (assert) {
+	const orgQuery = `σ a≤ 4 (R)`;
+	const orgCursor = { line: 1, column: 5 };
+	const ast = relalgjs.parseRelalg(orgQuery);
+
+	const { query, cursor } = relalgjs.queryWithReplacedOperatorsFromAst(orgQuery, ast.operatorPositions, orgCursor, 'math2plain');
+	assert.equal(query, `sigma a<= 4 (R)`);
+	assert.deepEqual(cursor, { line: 1, column: 10 });
+});


### PR DESCRIPTION
# Reference issue

https://github.com/dbis-uibk/relax/issues/174

# What does this implement/fix?

This PR includes:

- Fix for https://github.com/dbis-uibk/relax/issues/174;
- Fix for _math2plain_ replacement of relation except operator (before: `-`, after: `except`);
- Support for _plain2math_ and _math2plain_ replacement of:
  - rename columns operators (→, ->, ←, <-);
  - logical operators (∧, and, ∨, or, ⊻, xor, ¬, !, not);
  - comparison operators (≠, <>, !=, ≥, >=, ≤, <=);
- Add 50+ replacement unit tests.

# Tests

#### pi b (sigma a=0 R) https://github.com/dbis-uibk/relax/issues/174

- Before (backward conversion does NOT work):

1. Once the test query is written, click on `operator replacement` -> `pi => π`

<img width="1434" height="784" alt="Screenshot 2025-08-08 at 17 27 24" src="https://github.com/user-attachments/assets/ebcac115-9201-435e-9366-56001f1271f6" />

2. Then, click on `operator replacement` -> `π => pi`

<img width="1430" height="779" alt="Screenshot 2025-08-08 at 17 31 54" src="https://github.com/user-attachments/assets/23f13587-5d61-4cd8-9c88-090a65734711" />

- After (backward conversion DOES work):

1. Once the test query is written, click on `operator replacement` -> `pi => π`

<img width="1435" height="783" alt="Screenshot 2025-08-08 at 17 28 07" src="https://github.com/user-attachments/assets/518d70f4-a0f8-426b-ac48-51ac9d488b72" />

2. Then, click on `operator replacement` -> `π => pi`

<img width="1439" height="780" alt="Screenshot 2025-08-08 at 17 32 52" src="https://github.com/user-attachments/assets/2725f881-db1f-4c6f-9a77-10685c2e4d3c" />

#### Unit tests (operators replacement)

- Before:

<img width="1438" height="785" alt="Screenshot 2025-08-08 at 17 29 34" src="https://github.com/user-attachments/assets/77a0a55c-8eea-45f9-a890-49ad4d318641" />

- After:

<img width="1434" height="783" alt="Screenshot 2025-08-08 at 17 30 08" src="https://github.com/user-attachments/assets/593caddd-3462-400a-b7c0-2d7d224ea59c" />

