### PR TITLE
Fix history: add entry upfront and evict oldest (FIFO)

### DIFF
--- a/src/calc2/components/editorBagalg.tsx
+++ b/src/calc2/components/editorBagalg.tsx
@@ -73,6 +73,9 @@ export class EditorBagalg extends React.Component<Props, State> {
 				}}
 				mode="bagalg"
 				execFunction={(self: EditorBase, text: string, offset) => {
+					// add to history first
+					self.historyAddEntry(text);
+
 					const ast = parseRelalg(text, Object.keys(relations), false);
 					replaceVariables(ast, relations);
 
@@ -88,9 +91,6 @@ export class EditorBagalg extends React.Component<Props, State> {
 
 					const root = relalgFromRelalgAstRoot(ast, relations);
 					root.check();
-
-
-					self.historyAddEntry(text);
 
 					if (self.props.enableInlineRelationEditor) {
 						self.addInlineRelationMarkers(ast);

--- a/src/calc2/components/editorBase.tsx
+++ b/src/calc2/components/editorBase.tsx
@@ -1166,7 +1166,7 @@ export class EditorBase extends React.Component<Props, State> {
 			history: [
 				entry,
 				...this.state.history,
-			].slice(-historyMaxEntries),
+			].slice(0, historyMaxEntries),
 		});
 	}
 

--- a/src/calc2/components/editorRelalg.tsx
+++ b/src/calc2/components/editorRelalg.tsx
@@ -73,6 +73,9 @@ export class EditorRelalg extends React.Component<Props, State> {
 				}}
 				mode="relalg"
 				execFunction={(self: EditorBase, text: string, offset) => {
+					// add to history first
+					self.historyAddEntry(text);
+
 					const ast = parseRelalg(text, Object.keys(relations));
 					replaceVariables(ast, relations);
 
@@ -88,9 +91,6 @@ export class EditorRelalg extends React.Component<Props, State> {
 
 					const root = relalgFromRelalgAstRoot(ast, relations);
 					root.check();
-
-
-					self.historyAddEntry(text);
 
 					if (self.props.enableInlineRelationEditor) {
 						self.addInlineRelationMarkers(ast);

--- a/src/calc2/components/editorSql.tsx
+++ b/src/calc2/components/editorSql.tsx
@@ -64,6 +64,9 @@ export class EditorSql extends React.Component<Props> {
 				mode="text/x-mysql"
 				// @ts-ignore
 				execFunction={(self: EditorBase, text: string, offset) => {
+					// add to history first
+					self.historyAddEntry(text);
+
 					const ast = parseSQLSelect(text);
 					replaceVariables(ast, relations);
 			
@@ -82,9 +85,6 @@ export class EditorSql extends React.Component<Props> {
 			
 					if (root) {
 						root.check();
-						
-
-						self.historyAddEntry(text);
 
 						// calc.displayRaResult(root);
 						return {

--- a/src/calc2/components/editorTrc.tsx
+++ b/src/calc2/components/editorTrc.tsx
@@ -58,6 +58,7 @@ export class EditorTrc extends React.Component<Props, State> {
 				mode="trc"
 				// @ts-ignore
 				execFunction={(self: EditorBase, text: string, offset) => {
+					// add to history first
 					self.historyAddEntry(text);
 
 					const ast = parseTRCSelect(text);


### PR DESCRIPTION
# Reference issue

None.

# What does this implement/fix?

- Fixes a bug where the in-editor history could fill up and stop accepting new entries. History entries are now kept as a FIFO: the oldest entries are evicted when the max capacity is reached;
- Also documents/assumes that the per-mode editors (RelAlg, BagAlg, TRC, SQL, etc.) were updated to call [historyAddEntry(...)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) before running the execution logic, so the entry is persisted before any potentially crashing action runs.

# Tests

- Before (new entries are not inserted when history reaches full capacity):

<img width="1435" height="781" alt="Screenshot 2025-10-13 at 09 09 03" src="https://github.com/user-attachments/assets/68bf3a43-2fa6-4437-98a7-2e25edd5a20f" />

- After (new entries replace the oldest ones):

<img width="1434" height="778" alt="Screenshot 2025-10-13 at 09 21 22" src="https://github.com/user-attachments/assets/85dcc8fa-f89a-4f8c-ab03-3856c0e38040" />
