### PR TITLE
Improve alias-permutation search to avoid combinatorial explosion

### DIFF
--- a/src/db/exec/Projection.ts
+++ b/src/db/exec/Projection.ts
@@ -148,111 +148,138 @@ export class Projection extends RANodeUnary {
 					element.child.check(unProjectedSchema);
 				}
 				catch (e) {
-					// Second try: check wether projections use relation alias(es)
+					// Second try: check whether projections use relation alias(es)
 
-					// All columns names and aliases
-					let allCols: (string | number)[] = [];
-					let allRelAliases: (string | number)[] = [];
-					let allAltRelAliases: (string | number)[] = [];
-					// Ambiguous columns names
-					let blacklist: (string | number)[] = [];
+					// Collect column metadata and mark ambiguous columns (blacklist)
+					const allCols: string[] = [];
+					const allRelAliases: string[] = [];
+					const allAltRelAliases: string[] = [];
+					const blacklist: Set<string> = new Set();
 					const numCols = unProjectedSchema.getSize();
-					// Set first relation alias
 					let lastAlias = unProjectedSchema.getColumn(0).getRelAlias();
-					let k = 0;
-					for (let i = 0; i < numCols; i++) {
-						if (unProjectedSchema.getColumn(i).getRelAlias() !== lastAlias) {
-							lastAlias = unProjectedSchema.getColumn(i).getRelAlias();
-							if (k < vars.length - 1) k++;
+					let altIdx = 0;
+					for (let colIdx = 0; colIdx < numCols; colIdx++) {
+						const col = unProjectedSchema.getColumn(colIdx);
+						if (col.getRelAlias() !== lastAlias) {
+							lastAlias = col.getRelAlias();
+							if (altIdx < vars.length - 1) altIdx++;
 						}
 
-						allCols.push(unProjectedSchema.getColumn(i).getName());
-						allRelAliases.push(unProjectedSchema.getColumn(i).getRelAlias() as string);
-						allAltRelAliases.push(vars[k]);
+						const name = col.getName() + '';
+						allCols.push(name);
+						allRelAliases.push(col.getRelAlias() as string);
+						allAltRelAliases.push(vars[altIdx] || '');
 
-						// If column already in blacklist, skip it
-						// Cannot set relation alias for this column
-						if (blacklist.includes(unProjectedSchema.getColumn(i).getName())) {
-							continue;
-						}
-
-						for (let j = i+1; j < numCols; j++) {
-							// If found a sibling column, cannot set relation alias
-							if (unProjectedSchema.getColumn(i).getName() === unProjectedSchema.getColumn(j).getName()) {
-								blacklist.push(unProjectedSchema.getColumn(i).getName());
+						// mark ambiguous names
+						for (let j = colIdx + 1; j < numCols; j++) {
+							if (unProjectedSchema.getColumn(j).getName() === name) {
+								blacklist.add(name);
 								break;
 							}
 						}
 					}
 
-					// Unique columns names
-					// let whitelist = allCols.filter(x => !blacklist.includes(x));
-					
-					// Generate all column combinations
-					// https://stackoverflow.com/questions/43241174/javascript-generating-all-combinations-of-elements-in-a-single-array-in-pairs
-					let combCols = [];
-					let combRelAliases = [];
-					let combTempRelAliases = [];
-					let temp = [];
-					let tempAliases = [];
-					let tempAltAliases = [];
-					let slent = Math.pow(2, allCols.length);
-
-					for (let i = 0; i < slent; i++) {
-						temp = [];
-						tempAliases = [];
-						tempAltAliases = [];
-						for (var j = 0; j < allCols.length; j++) {
-							if ((i & Math.pow(2, j))) {
-								temp.push(allCols[j]);
-								tempAliases.push(allRelAliases[j]);
-								tempAltAliases.push(allAltRelAliases[j]);
-							}
-						}
-						if (temp.length > 0) {
-							combCols.push(temp);
-							combRelAliases.push(tempAliases);
-							combTempRelAliases.push(tempAltAliases);
+					// Candidate indices to try changing alias: not blacklisted and alt alias differs
+					const candidateIndices: number[] = [];
+					for (let idx = 0; idx < allCols.length; idx++) {
+						if (!blacklist.has(allCols[idx]) && allRelAliases[idx] !== allAltRelAliases[idx]) {
+							candidateIndices.push(idx);
 						}
 					}
 
-					// Test if relation alias(es) works for any combination of columns
-					let schemaWorked = false;
-					
-					for (let i = 0; i < combCols.length; i++) {
-						let newSchema = unProjectedSchema.copy();
+					const MAX_COMBINATIONS = 1_000_000;
+					const m = candidateIndices.length;
+					if (m === 0) {
+						// Nothing to try
+						this.throwExecutionError(e.message);
+					}
 
-						for (let j = 0; j < combCols[i].length; j++) {
-
-							for (let k = 0; k < numCols; k++) {
-								if (combCols[i][j] === newSchema.getColumn(k).getName() &&
-									combRelAliases[i][j] === newSchema.getColumn(k).getRelAlias() &&
-									!blacklist.includes(combCols[i][j])) {
-									// Set relation alias
-									try {
-										newSchema.setRelAlias(String(combTempRelAliases[i][j]), k);
-									}
-									catch (e) {
-										// Test failed, try next combination
-										break;
-									}
+					const totalCombinations = Math.pow(2, m) - 1; // non-empty subsets
+					if (totalCombinations > MAX_COMBINATIONS) {
+						console.warn(`Check aborted: too many alias combinations in projection (${totalCombinations})`);
+						// Build projected schema from the projection columns themselves
+						const tempIndices: number[] = [];
+						const projectedSchema = new Schema();
+						for (let pi = 0; pi < this._columns.length; pi++) {
+							const p = this._columns[pi];
+							if (p instanceof Column) {
+								const col = p as Column;
+								const name = col.getName();
+								const relAlias = col.getRelAlias();
+								let index = -1;
+								try {
+									index = unProjectedSchema.getColumnIndex(name, relAlias as any);
 								}
+								catch (ex) {
+									index = -1;
+								}
+
+								if (index !== -1) {
+									const type = unProjectedSchema.getType(index);
+									projectedSchema.addColumn(name, relAlias as any, type);
+								}
+								else {
+									projectedSchema.addColumn(name, relAlias as any, 'string');
+								}
+
+								tempIndices.push(index);
+							}
+							else {
+								const expr = p as ProjectionColumnExpr;
+								const dtype = expr.child.getDataType();
+								const dataType = (dtype === 'null' || dtype === null) ? 'string' : dtype as any;
+								projectedSchema.addColumn(expr.name, expr.relAlias, dataType);
+								tempIndices.push(-1);
 							}
 						}
 
-						// Check if combination of relation alias works
+						this._checked = {
+							_indices: tempIndices,
+							_projectedSchema: projectedSchema,
+						};
+						return;
+					}
+
+					// Try subsets of candidate indices (non-empty)
+					let schemaWorked = false;
+					const startTime = Date.now();
+					let tried = 0;
+					const limitLogEvery = 1000;
+
+					const subsets = (1 << m);
+					for (let mask = 1; mask < subsets; mask++) {
+						tried++;
+						// periodic logging
+						if ((tried % limitLogEvery) === 0) {
+							const elapsed = Date.now() - startTime;
+							console.log(`[Projection alias retry] tried ${tried}/${totalCombinations} combinations in ${elapsed}ms`);
+						}
+
+						const newSchema = unProjectedSchema.copy();
+						let failedSetting = false;
+						for (let bit = 0; bit < m; bit++) {
+							if ((mask & (1 << bit)) === 0) continue;
+							const colPos = candidateIndices[bit];
+							try {
+								newSchema.setRelAlias(String(allAltRelAliases[colPos]), colPos);
+							}
+							catch (ex) {
+								failedSetting = true;
+								break;
+							}
+						}
+						if (failedSetting) continue;
+
 						try {
 							element.child.check(newSchema);
 							schemaWorked = true;
 							break;
 						}
-						catch (e) {
-							// Test failed, try next combination
+						catch (ex) {
 							continue;
 						}
 					}
 
-					// If no combination of relation alias works
 					if (!schemaWorked) {
 						this.throwExecutionError(e.message);
 					}


### PR DESCRIPTION
# Reference issue

None.

# What does this implement/fix?

- Replaces brute-force enumeration of all column subsets used for relation-alias retries with a much more efficient, candidate-based search;
- Limits the search space by:
  - Considering only candidate columns (non-ambiguous names and where the current alias differs from an alternate alias);
  - Pre-checking the estimated number of combinations and aborting early if it exceeds a safe cap;
  - Enforcing a short runtime timeout for the search;
- Reduces allocations and work by copying the schema only once per attempted mask and skipping masks that would fail quickly;
- Adds periodic logging during long searches so the runtime progress is visible during debugging;
- Keeps original semantics where possible: if no alias-permutation makes the predicate check succeed, the original execution error is rethrown (or an abort/timeout error is raised when the search is intentionally stopped);
- Fix https://github.com/dbis-uibk/relax/issues/265

## Behavioral notes

- New safety limits:
  - A maximum combinations cap prevents exponential blow-ups (configurable constants in the code);
  - A short timeout aborts runaway searches;
  - When the search is aborted (too many combinations or timeout), a clear abort error is thrown to avoid CPU/memory exhaustion;
- For most normal schemas this is dramatically faster and avoids hangs/crashes. For edge cases where exhaustive alias search was previously desired, the code now intentionally fails early; this is safer for browser/host stability.

# How to test this PR?

Test it live at https://dbis-uibk.github.io/relax/calc/local/ufes/local/3

- Before

Without the proposed changes, the web browser freezes and then crashes with the following query:

```sql
pi
    constructors.name -> Equipe,
    CONCAT(drivers.forename, ' ', drivers.surname) -> Piloto,
    circuits.name -> Circuito,
    races.year -> Ano
(
    constructors
    left join constructors.constructorId = results.constructorId 
        and constructors.nationality = 'French' results
    join results.driverId = drivers.driverId 
        and results.positionOrder = 1 drivers
    join results.raceId = races.raceId races
    join races.circuitId = circuits.circuitId circuits
)
```

<img width="1436" height="780" alt="Screenshot 2025-10-14 at 15 37 18" src="https://github.com/user-attachments/assets/408e2b31-8011-4829-b316-6a687068899d" />

- After, the calculator works just fine!

<img width="1434" height="780" alt="Screenshot 2025-10-14 at 15 38 23" src="https://github.com/user-attachments/assets/6aef2c03-b1d6-41ec-9e59-3e50f7a80ead" />
