### PR TITLE
Fix CodeMirror gutter overlay issue in Group editor

### DIFF
--- a/src/calc2/components/calculator.tsx
+++ b/src/calc2/components/calculator.tsx
@@ -260,7 +260,14 @@ example,  42
 					</div>
 				</div>
 
-				<Modal isOpen={this.state.datasetModal} toggle={this.toggleDatasetModal}>
+				<Modal
+					isOpen={this.state.datasetModal}
+					toggle={this.toggleDatasetModal}
+					onClosed={() => {
+						const editor: any = this.getCurrentEditor().current;
+						editor?.editorBase?.state?.editor?.refresh?.();
+					}}
+				>
 					<ModalHeader toggle={this.toggleDatasetModal}>{translateHeader(group.groupName, locale)}</ModalHeader>
 					<ModalBody>
 						<div>


### PR DESCRIPTION
# Reference issues

https://github.com/dbis-uibk/relax/issues/189
https://github.com/dbis-uibk/relax/issues/193

# What does this implement/fix?

Fixes a CodeMirror gutter layout issue in the Group editor when loading example content.

**Problem:** When opening the Group editor with example content (via "Create new group"), the line number gutter overlays the text instead of being positioned correctly beside it. This occurs because CodeMirror calculates gutter dimensions while the editor is hidden during tab switching and modal closing animations, resulting in incorrect measurements.

**Solution:** Added a `refresh()` call in the modal's `onClosed` callback to force CodeMirror to recalculate its layout after the modal fully closes and the editor becomes visible. This ensures proper gutter positioning for both scenarios:

- Loading existing group definitions (already working)
- Loading example content for new groups (previously broken)

**Technical details:** The `refresh()` method triggers CodeMirror to remeasure its DOM elements and recompute positioning. This is necessary whenever an editor becomes visible after being hidden or when its container undergoes layout changes.

![demo](https://github.com/user-attachments/assets/ea906d0a-74a0-428c-a093-3e02614265a9)
