### PR TITLE
Ensure consistent group initialization and scoped error handling in group loading

### DIFF
--- a/src/calc2/calculator.entry.tsx
+++ b/src/calc2/calculator.entry.tsx
@@ -33,6 +33,7 @@ ReactDOM.render(
 		locale: i18n.language,
 	};
 
+	// load all predefined groups
 	for (const action of loadStaticGroups()) {
 		store.dispatch(action);
 	}

--- a/src/calc2/calculator.entry.tsx
+++ b/src/calc2/calculator.entry.tsx
@@ -26,17 +26,14 @@ ReactDOM.render(
 	document.getElementById('root'),
 );
 
-
 // init
 {
 	const action: SET_LOCALE = {
 		type: 'SET_LOCALE',
 		locale: i18n.language,
 	};
-	store.dispatch(action);
-}
 
-// load all predefined groups
-for (const action of loadStaticGroups()) {
-	store.dispatch(action);
+	for (const action of loadStaticGroups()) {
+		store.dispatch(action);
+	}
 }

--- a/src/calc2/utils/groupUtils.ts
+++ b/src/calc2/utils/groupUtils.ts
@@ -180,6 +180,9 @@ export function loadGroupsFromSource(source: GroupSourceType, id: string, mainta
           success: gist_success,
           crossDomain: true,
           statusCode: {
+            403: function (data: any) {
+              reject(new Error(data.responseJSON.message));
+            },
             404: function () {
               // tslint:disable-next-line: prefer-template
               reject(new Error('gist ' + id + ' not found'));

--- a/src/calc2/views/calc.tsx
+++ b/src/calc2/views/calc.tsx
@@ -38,6 +38,8 @@ export class Calc extends React.Component<Props> {
 	private init: boolean;
 	private apiView: boolean = false;
 	private params: any = {};
+	private currentLoadGroupRequestId: string | null = null;
+	private loadGroupPending: boolean = false;
 	
 	constructor(props: Props) {
 		super(props);
@@ -58,6 +60,16 @@ export class Calc extends React.Component<Props> {
 	}
 
 	componentDidUpdate(prevProps: Props): void {
+		// Show alert only if error comes from our explicit loadGroup call
+		if (
+			this.loadGroupPending &&
+			this.props.groups.error &&
+			this.props.groups.errorRequestId === this.currentLoadGroupRequestId
+		) {
+			alert(this.props.groups.error);
+			this.loadGroupPending = false;
+		}
+
 		const { params } = this.props.match;
 		const { params: prevParams } = prevProps.match;
 		if (
@@ -74,8 +86,13 @@ export class Calc extends React.Component<Props> {
 	}
 
 	private loadGroup(props: Props) {
-		const { source, id, filename, index } = props.match.params;
+		const { source, id, filename = '', index = '0' } = props.match.params;
+		const requestId = `${source}/${id}/${filename}/${index}`;
 
+		// mark that we triggered a load explicitly
+		this.currentLoadGroupRequestId = requestId;
+		this.loadGroupPending = true;
+		
 		this.props.loadGroup(source, id, filename, Number.parseInt(index, 10), '', '');
 		// TODO: display errors
 	}


### PR DESCRIPTION
# Reference issue

https://github.com/dbis-uibk/relax/issues/258

# What does this implement/fix?

## **1. Prevent duplicate store initialization and ensure consistent group loading on startup**

### **Problem**
Previously, the app dispatched `SET_LOCALE` and `loadStaticGroups()` separately during startup.  
When the user changed the language (e.g., from English to another locale), the page reload triggered both actions again — causing `loadStaticGroups()` to execute twice.  
This led to redundant Redux updates, race conditions, and inconsistent group state initialization.

### **Solution**
- Removed redundant conditional dispatch of `SET_LOCALE`.
- Ensured `loadStaticGroups()` runs **exactly** once after startup.
- Simplified initialization so locale setup and group loading happen in a single consistent block.
  ![demo01](https://github.com/user-attachments/assets/0bc193b0-fffa-4289-b9ae-5cc0f1b8c268)
- Prevented unnecessary store re-initialization while keeping expected reload behavior intact when switching languages.
  ![demo02](https://github.com/user-attachments/assets/b173c771-ebbb-4433-bec5-fc8ecc0fecca)

## **2. Add scoped error tracking and feedback for group loading in Calc component**

### **Problem**
Before this refactor:
- GitHub Gist rate-limited responses (HTTP 403) were not handled properly.
- There was no way to determine whether a redux group-related error was caused by the latest `loadGroup()` call.
- Users often saw no feedback when a group failed to load.

### **Solution**
- Added two new internal tracking fields in the Calc component:
  - `currentLoadGroupRequestId`: tracks the specific request that originated the latest load.
  - `loadGroupPending`: marks whether a load operation is in progress.
- Updated `componentDidUpdate()` to:
  - Show an alert when there’s a Redux error **linked** to the tracked request.
    <img width="1552" height="987" alt="Screenshot 2025-11-10 at 03 00 53" src="https://github.com/user-attachments/assets/42565834-bdc8-421e-b5ad-bcfc140eb11c" />

  - Reset `loadGroupPending` once the alert is displayed.
- Added `error` and `errorRequestId` fields in the Redux store.
- Introduced a new `GROUPS_LOAD_ERROR` action:
  ```ts
  {
    type: 'GROUPS_LOAD_ERROR',
    error: string,
    requestId: string,
  }
- Each saga now generates a unique `requestId` for its load operation, ensuring proper error scoping.
- Added explicit handling for HTTP 403 responses with clear error feedback.
