### PR TITLE
Fix LIKE / ILIKE '_' wildcard for 3+ consecutive underscores in regex translation

### DIFF
--- a/src/db/exec/ValueExpr.ts
+++ b/src/db/exec/ValueExpr.ts
@@ -658,8 +658,14 @@ export class ValueExprGeneric extends ValueExpr {
 				// cache regex
 				const value = this._args[1]._args[0]; // direct access of constant value
 				let regex_str = regExpEscape(value);
-				regex_str = regex_str.replace(/([^\\]?)_/g, '$1.');
-				regex_str = regex_str.replace(/([^\\]?)%/g, '$1.*');
+				regex_str = regex_str.replace(/\\_/g, '__ESCAPED_UNDERSCORE__'); // temp protect escaped _
+				regex_str = regex_str.replace(/_/g, '.');
+				regex_str = regex_str.replace(/\\%/g, '__ESCAPED_PERCENT__');   // temp protect escaped %
+				regex_str = regex_str.replace(/%/g, '.*');
+
+				// restore escaped literals
+				regex_str = regex_str.replace(/__ESCAPED_UNDERSCORE__/g, '_');
+				regex_str = regex_str.replace(/__ESCAPED_PERCENT__/g, '%');
 
 				const flags = this._func === 'ilike' ? 'i' : '';
 


### PR DESCRIPTION
# Reference issues

https://github.com/dbis-uibk/relax/issues/275

# What does this implement/fix?

Correct mapping of `LIKE`/`ILIKE` underscores (_) to regex single-character wildcard when 3 or more underscores are consecutive.
