### PR TITLE
feat: add JSON export for execution plan

### DIFF
--- a/src/calc2/components/editorBase.tsx
+++ b/src/calc2/components/editorBase.tsx
@@ -14,7 +14,7 @@ import { Group } from 'calc2/store/groups';
 import classNames from 'classnames';
 import * as CodeMirror from 'codemirror';
 import 'codemirror/addon/hint/show-hint';
-import { RANode, RANodeBinary, RANodeUnary } from 'db/exec/RANode';
+import { RANode, RANodeBinary, RANodeUnary, raNodeToJSON } from 'db/exec/RANode';
 import { forEachPreOrder } from 'db/translate/utils';
 import * as React from 'react';
 import { findDOMNode } from 'react-dom';
@@ -35,7 +35,8 @@ import {
 	faTable,
 	faFileDownload,
 	faImage,
-	faFileCsv  
+	faFileCsv,
+	faFileCode
 } from '@fortawesome/free-solid-svg-icons';
 
 require('codemirror/lib/codemirror.css');
@@ -541,6 +542,7 @@ type State = {
 	replSelStart: any,
 	replSelEnd: any,
 	queryResult: any,
+	raRoot: RANode | null,
 	execTime: any,
 	addedExampleSqlQuery: boolean,
 	addedExampleBagsQuery: boolean,
@@ -893,6 +895,7 @@ export class EditorBase extends React.Component<Props, State> {
 			replSelStart: null,
 			replSelEnd: null,
 			queryResult: null,
+			raRoot: null,
 			execTime: null,
 			addedExampleSqlQuery: false,
 			addedExampleBagsQuery: false,
@@ -1194,8 +1197,16 @@ export class EditorBase extends React.Component<Props, State> {
 											),
 									 	value: '',
 									},
+									{
+										label: (
+											<>
+											<div color="Link" onClick={this.downloadQueryResult} data-id="json"><FontAwesomeIcon icon={faFileCode  as IconProp}/> <span ><T id="calc.editors.ra.button-download-json" /></span></div>
+											</>
+											),
+									 	value: '',
+									},
 									]
-										
+
 									}
 									/>
 							</div>
@@ -1522,8 +1533,19 @@ export class EditorBase extends React.Component<Props, State> {
 				a.download = filename;
 				a.click();
 				break;
+			case 'json':
+				const { raRoot } = this.state;
+				if (!raRoot) {
+					return;
+				}
+				const json = JSON.stringify(raNodeToJSON(raRoot), null, 2);
+				const b = document.createElement('a');
+				b.href = window.URL.createObjectURL(new Blob([json], { 'type': 'application/json' }));
+				b.download = 'result.json';
+				b.click();
+				break;
 			default:
-				return;	
+				return;
 		}
 	}
 
@@ -1776,6 +1798,7 @@ export class EditorBase extends React.Component<Props, State> {
 				this.getResultForCsv(result.props.root);
 				this.setState({
 					execResult: result,
+					raRoot: result.props.root,
 					execTime: end,
 				});
 				const event = new CustomEvent(eventExecSuccessfulName, {

--- a/src/db/exec/Difference.ts
+++ b/src/db/exec/Difference.ts
@@ -21,7 +21,7 @@ export class Difference extends RANodeBinary {
 		/** the right child expression */
 		child2: RANode,
 	) {
-		super('-', child, child2);
+		super('-', child, child2, 'difference');
 	}
 
 	getSchema() {

--- a/src/db/exec/Division.ts
+++ b/src/db/exec/Division.ts
@@ -19,7 +19,7 @@ export class Division extends RANodeBinary {
 	private _delegate: RANode | null = null;
 
 	constructor(child: RANode, child2: RANode) {
-		super('÷', child, child2);
+		super('÷', child, child2, 'division');
 	}
 
 	getSchema() {

--- a/src/db/exec/EliminateDuplicates.ts
+++ b/src/db/exec/EliminateDuplicates.ts
@@ -20,7 +20,7 @@ export class EliminateDuplicates extends RANodeUnary {
 	private _schema: Schema | null = null;
 
 	constructor(child: RANode) {
-		super('∂', child);
+		super('∂', child, 'eliminateDuplicates');
 	}
 
 	getSchema() {

--- a/src/db/exec/GroupBy.ts
+++ b/src/db/exec/GroupBy.ts
@@ -47,7 +47,7 @@ export class GroupBy extends RANodeUnary {
 	} | null = null;
 
 	constructor(child: RANode, groupByCols: GroupByCol[], aggregateFunctions: AggregateFunction[]) {
-		super('&gamma;', child);
+		super('&gamma;', child, 'groupBy');
 
 		this.groupByCols = groupByCols;
 		this.aggregateFunctions = aggregateFunctions;

--- a/src/db/exec/Intersect.ts
+++ b/src/db/exec/Intersect.ts
@@ -18,7 +18,7 @@ export class Intersect extends RANodeBinary {
 	private _schema: Schema | null = null; // is set by check
 
 	constructor(child: RANode, child2: RANode) {
-		super('∩', child, child2);
+		super('∩', child, child2, 'intersect');
 	}
 
 	getSchema() {

--- a/src/db/exec/OrderBy.ts
+++ b/src/db/exec/OrderBy.ts
@@ -24,7 +24,7 @@ export class OrderBy extends RANodeUnary {
 	_orderIndices: number[] | null;
 
 	constructor(child: RANode, orderCols: Column[], orderAsc: boolean[]) {
-		super('&tau;', child);
+		super('&tau;', child, 'orderBy');
 
 		this._orderCols = orderCols;
 		this._orderAsc = orderAsc;

--- a/src/db/exec/Projection.ts
+++ b/src/db/exec/Projection.ts
@@ -32,7 +32,7 @@ export class Projection extends RANodeUnary {
 	} | null = null;
 
 	constructor(child: RANode, proj: ProjectionColumn[]) {
-		super('&pi;', child);
+		super('&pi;', child, 'projection');
 		this._columns = proj;
 	}
 

--- a/src/db/exec/RANode.ts
+++ b/src/db/exec/RANode.ts
@@ -45,6 +45,7 @@ export interface MetaData extends Object {
  */
 export abstract class RANode {
 	_functionName: string;
+	private _operationType: string | null;
 	_codeInfo: CodeInfo | null = null;
 	_metaData: MetaData = {};
 	_resultNumRows: number = -1;
@@ -52,8 +53,13 @@ export abstract class RANode {
 	_warnings: Warning[] = [];
 	_execTime: any;
 	
-	constructor(functionName = '') {
+	constructor(functionName = '', operationType: string | null = null) {
 		this._functionName = functionName;
+		this._operationType = operationType;
+	}
+
+	getOperationType(): string {
+		return this._operationType || this._functionName;
 	}
 
 	setCodeInfoObject(codeInfo: CodeInfo | null) {
@@ -174,6 +180,10 @@ export abstract class RANode {
 }
 
 export abstract class RANodeNullary extends RANode {
+	constructor(functionName: string, operationType: string | null = null) {
+		super(functionName, operationType);
+	}
+
 	getWarnings(recursive: boolean): Warning[] {
 		return this._warnings;
 	}
@@ -193,8 +203,8 @@ export abstract class RANodeNullary extends RANode {
 export abstract class RANodeUnary extends RANode {
 	protected _child: RANode;
 
-	constructor(functionName: string, child: RANode) {
-		super(functionName);
+	constructor(functionName: string, child: RANode, operationType: string | null = null) {
+		super(functionName, operationType);
 		this._child = child;
 	}
 
@@ -230,8 +240,8 @@ export abstract class RANodeBinary extends RANode {
 	protected _child: RANode;
 	protected _child2: RANode;
 
-	constructor(functionName: string, child: RANode, child2: RANode) {
-		super(functionName);
+	constructor(functionName: string, child: RANode, child2: RANode, operationType: string | null = null) {
+		super(functionName, operationType);
 		this._child = child;
 		this._child2 = child2;
 	}
@@ -271,4 +281,117 @@ export abstract class RANodeBinary extends RANode {
 			${wrap ? ')' : ''}`
 		);
 	}
+}
+
+const fallbackHtmlEntities: { [key: string]: string } = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+	'#39': "'",
+};
+
+function decodeHtmlEntities(str: string): string {
+	if (typeof document !== 'undefined') {
+		const textarea = document.createElement('textarea');
+		textarea.innerHTML = str;
+		return textarea.value;
+	}
+
+	return str.replace(/&(#x[0-9a-f]+|#[0-9]+|[a-z0-9]+);/gi, (match, entity) => {
+		if (entity[0] === '#') {
+			const radix = entity[1].toLowerCase() === 'x' ? 16 : 10;
+			const codePoint = parseInt(entity.slice(radix === 16 ? 2 : 1), radix);
+			return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint);
+		}
+
+		return fallbackHtmlEntities[entity.toLowerCase()] || match;
+	});
+}
+
+function htmlToText(html: string): string {
+	if (typeof document !== 'undefined') {
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		return (container.textContent || '').trim();
+	}
+
+	return html
+		.replace(/<[^>]*>/g, '')
+		.replace(/\s+/g, ' ')
+		.split('\n')
+		.join('')
+		.trim();
+}
+
+function stripHtmlTags(html: string): string {
+	return decodeHtmlEntities(htmlToText(html))
+		.trim();
+}
+
+function getOperationSymbol(node: RANode): string {
+	const formulaHtml = node.getFormulaHtml(false, false);
+	let operatorHtml = node._functionName;
+
+	if (typeof document !== 'undefined') {
+		const container = document.createElement('div');
+		container.innerHTML = formulaHtml;
+		const operatorElement = container.querySelector('.math');
+		return (operatorElement && operatorElement.textContent || stripHtmlTags(operatorHtml)).trim();
+	}
+
+	const match = formulaHtml.match(/<span\s+class=["'][^"']*\bmath\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i);
+	if (match) {
+		operatorHtml = match[1];
+	}
+
+	return stripHtmlTags(operatorHtml);
+}
+
+function schemaToJSON(schema: Schema): { columns: { name: string | number, relAlias: string | null, type: string }[] } {
+	const columns = [];
+	for (let i = 0; i < schema.getSize(); i++) {
+		const col = schema.getColumn(i);
+		columns.push({
+			name: col.getName(),
+			relAlias: col.getRelAlias(),
+			type: schema.getType(i),
+		});
+	}
+	return { columns };
+}
+
+export function raNodeToJSON(node: RANode): object {
+	const functionName = node._functionName;
+
+	const result: any = {};
+
+	if (node instanceof RANodeNullary) {
+		result.operationType = node.getOperationType();
+		result.name = functionName;
+	}
+	else {
+		result.operationType = node.getOperationType();
+		result.operationSymbol = getOperationSymbol(node);
+	}
+
+	const argumentHtml = node.getArgumentHtml();
+	const args = stripHtmlTags(argumentHtml);
+	if (args.length > 0) {
+		result.arguments = args;
+	}
+
+	result.resultNumRows = node._resultNumRows;
+	result.schema = schemaToJSON(node.getSchema());
+
+	if (node instanceof RANodeBinary) {
+		result.left = raNodeToJSON(node.getChild());
+		result.right = raNodeToJSON(node.getChild2());
+	}
+	else if (node instanceof RANodeUnary) {
+		result.child = raNodeToJSON(node.getChild());
+	}
+
+	return result;
 }

--- a/src/db/exec/Relation.ts
+++ b/src/db/exec/Relation.ts
@@ -21,7 +21,7 @@ export class Relation extends RANodeNullary {
 		/** relation is filled by evaluating the node */
 		content?: RANode,
 	) {
-		super(functionName);
+		super(functionName, 'relation');
 		if (content === undefined) {
 			this._table = new Table();
 		}

--- a/src/db/exec/RenameColumns.ts
+++ b/src/db/exec/RenameColumns.ts
@@ -24,7 +24,7 @@ export class RenameColumns extends RANodeUnary {
     _schema: Schema | null = null;
 
     constructor(child: RANode) {
-        super('&rho;', child);
+        super('&rho;', child, 'renameColumns');
     }
 
     getSchema() {

--- a/src/db/exec/RenameRelation.ts
+++ b/src/db/exec/RenameRelation.ts
@@ -21,7 +21,7 @@ export class RenameRelation extends RANodeUnary {
 	_schema: Schema | null = null;
 
 	constructor(child: RANode, newRelAlias: string) {
-		super('&rho;', child);
+		super('&rho;', child, 'renameRelation');
 
 		this._newRelAlias = newRelAlias;
 	}

--- a/src/db/exec/Selection.ts
+++ b/src/db/exec/Selection.ts
@@ -16,7 +16,7 @@ export class Selection extends RANodeUnary {
 	private _schema: Schema | null = null;
 
 	constructor(child: RANode, condition: ValueExpr.ValueExpr) {
-		super('&sigma;', child);
+		super('&sigma;', child, 'selection');
 		this._condition = condition;
 
 		if (condition instanceof ValueExpr.ValueExpr === false) {

--- a/src/db/exec/Union.ts
+++ b/src/db/exec/Union.ts
@@ -20,7 +20,7 @@ export class Union extends RANodeBinary {
 	private _schema: Schema | null = null;
 
 	constructor(child: RANode, child2: RANode) {
-		super('∪', child, child2);
+		super('∪', child, child2, 'union');
 
 		this._schema = null; // is set by check
 	}

--- a/src/db/exec/joins/AntiJoin.ts
+++ b/src/db/exec/joins/AntiJoin.ts
@@ -14,7 +14,7 @@ import * as i18n from 'i18next';
  */
 export class AntiJoin extends Join {
 	constructor(child: RANode, child2: RANode, condition: JoinCondition) {
-		super(child, child2, '▷', condition, false, true);
+		super(child, child2, '▷', 'antiJoin', condition, false, true);
 	}
 
 	_checkSchema(schemaA: Schema, schemaB: Schema): void {

--- a/src/db/exec/joins/CrossJoin.ts
+++ b/src/db/exec/joins/CrossJoin.ts
@@ -19,7 +19,7 @@ import { Join } from './Join';
 export class CrossJoin extends Join {
 	constructor(child: RANode, child2: RANode) {
 		const joinCondition: ValueExpr.ValueExpr = new ValueExpr.ValueExprGeneric('boolean', 'constant', [true]);
-		super(child, child2, '⨯', {
+		super(child, child2, '⨯', 'crossJoin', {
 			type: 'theta',
 			joinExpression: joinCondition,
 		}, false);

--- a/src/db/exec/joins/FullOuterJoin.ts
+++ b/src/db/exec/joins/FullOuterJoin.ts
@@ -25,7 +25,7 @@ import { Join, JoinCondition } from './Join';
  */
 export class FullOuterJoin extends Join {
 	constructor(child: RANode, child2: RANode, condition: JoinCondition) {
-		super(child, child2, '⟗', condition, false);
+		super(child, child2, '⟗', 'fullOuterJoin', condition, false);
 	}
 
 	setChild2(child2: RANode) {

--- a/src/db/exec/joins/InnerJoin.ts
+++ b/src/db/exec/joins/InnerJoin.ts
@@ -17,7 +17,7 @@ import { Join, JoinCondition } from './Join';
  */
 export class InnerJoin extends Join {
 	constructor(child: RANode, child2: RANode, condition: JoinCondition) {
-		super(child, child2, '⨝', condition, false);
+		super(child, child2, '⨝', 'innerJoin', condition, false);
 	}
 
 	_checkSchema(schemaA: Schema, schemaB: Schema): void {

--- a/src/db/exec/joins/Join.ts
+++ b/src/db/exec/joins/Join.ts
@@ -53,6 +53,7 @@ export abstract class Join extends RANodeBinary {
 		child: RANode,
 		child2: RANode,
 		functionName: string,
+		operationType: string,
 		/** condition is either a ValueExpr evaluating to boolean
 		 * or an Array of unqualified column names as strings for the using clause or
 		 * null for a natural join 
@@ -61,7 +62,7 @@ export abstract class Join extends RANodeBinary {
 		isRightJoin: boolean,
 		isAntiJoin = false,
 	) {
-		super(functionName, child, child2);
+		super(functionName, child, child2, operationType);
 		this._isAntiJoin = isAntiJoin;
 		this._isRightJoin = isRightJoin;
 		this._joinConditionOptions = joinCondition;

--- a/src/db/exec/joins/LeftOuterJoin.ts
+++ b/src/db/exec/joins/LeftOuterJoin.ts
@@ -24,7 +24,7 @@ import { Join, JoinCondition } from './Join';
  */
 export class LeftOuterJoin extends Join {
 	constructor(child: RANode, child2: RANode, condition: JoinCondition) {
-		super(child, child2, '⟕', condition, false);
+		super(child, child2, '⟕', 'leftOuterJoin', condition, false);
 	}
 
 	_checkSchema(schemaA: Schema, schemaB: Schema): void {

--- a/src/db/exec/joins/RightOuterJoin.ts
+++ b/src/db/exec/joins/RightOuterJoin.ts
@@ -23,7 +23,7 @@ import { Join, JoinCondition } from './Join';
  */
 export class RightOuterJoin extends Join {
 	constructor(child: RANode, child2: RANode, condition: JoinCondition) {
-		super(child, child2, '⟖', condition, true);
+		super(child, child2, '⟖', 'rightOuterJoin', condition, true);
 	}
 
 	_checkSchema(schemaA: Schema, schemaB: Schema): void {

--- a/src/db/exec/joins/SemiJoin.ts
+++ b/src/db/exec/joins/SemiJoin.ts
@@ -20,7 +20,7 @@ import { Join } from './Join';
  */
 export class SemiJoin extends Join {
 	constructor(child: RANode, child2: RANode, isLeftSemiJoin: boolean) {
-		super(child, child2, (isLeftSemiJoin ? '⋉' : '⋊'), {
+		super(child, child2, (isLeftSemiJoin ? '⋉' : '⋊'), (isLeftSemiJoin ? 'leftSemiJoin' : 'rightSemiJoin'), {
 			type: 'natural',
 			restrictToColumns: null,
 		}, !isLeftSemiJoin);

--- a/src/db/tests/ra_node_to_json_tests.ts
+++ b/src/db/tests/ra_node_to_json_tests.ts
@@ -1,0 +1,239 @@
+/*** Copyright 2016 Johannes Kessler 2016 Johannes Kessler
+*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Relation } from 'db/exec/Relation';
+import { RANode, RANodeUnary, raNodeToJSON, Session } from 'db/exec/RANode';
+import { Table } from 'db/exec/Table';
+import * as relalgjs from '../relalg';
+
+QUnit.module('raNodeToJSON');
+
+function exec_ra(query: string, relations: { [key: string]: Relation }) {
+	return relalgjs.executeRelalg(query, relations);
+}
+
+class FormulaOperatorNode extends RANodeUnary {
+	constructor(child: RANode) {
+		super('internalOperatorName', child, 'formulaOperator');
+	}
+
+	check(): void {
+		this.getChild().check();
+	}
+
+	getSchema() {
+		return this.getChild().getSchema();
+	}
+
+	getResult(doEliminateDuplicateRows: boolean = true, session?: Session): Table {
+		const result = this.getChild().getResult(doEliminateDuplicateRows, session);
+		this.setResultNumRows(result.getNumRows());
+		return result;
+	}
+
+	getFormulaHtml(): string {
+		return '<span><span class="math">&#8904;</span></span>';
+	}
+}
+
+function exec_bags(query: string, relations: { [key: string]: Relation }) {
+	return relalgjs.executeRelalg(query, relations, false);
+}
+
+function getTestRelations() {
+	const R = relalgjs.executeRelalg(`{
+		R.a:number, R.b:string, R.c:string
+
+		1,   a,   d
+		3,   c,   c
+		4,   d,   f
+		5,   d,   b
+		6,   e,   f
+	}`, {});
+
+	const S = relalgjs.executeRelalg(`{
+		S.b:string, S.d:number
+
+		a,   100
+		b,   300
+		c,   400
+		d,   200
+		e,   150
+	}`, {});
+
+	return {
+		R: new Relation('R', R),
+		S: new Relation('S', S),
+	};
+}
+
+
+QUnit.test('nullary node (relation)', function (assert) {
+	const relations = getTestRelations();
+	const root = exec_ra('R', relations);
+	root.getResult();
+	const json: any = raNodeToJSON(root);
+
+	assert.equal(json.operationType, 'relation');
+	assert.equal(json.name, 'R');
+	assert.equal(json.resultNumRows, 5);
+	assert.equal(json.schema.columns.length, 3);
+	assert.equal(json.schema.columns[0].name, 'a');
+	assert.equal(json.schema.columns[0].relAlias, 'R');
+	assert.equal(json.schema.columns[0].type, 'number');
+	assert.ok(!json.child);
+	assert.ok(!json.left);
+	assert.ok(!json.right);
+	assert.ok(!json.operationSymbol);
+});
+
+
+QUnit.test('unary node (selection)', function (assert) {
+	const relations = getTestRelations();
+	const root = exec_ra('sigma R.a > 3 (R)', relations);
+	root.getResult();
+	const json: any = raNodeToJSON(root);
+
+	assert.equal(json.operationType, 'selection');
+	assert.equal(json.operationSymbol, 'σ');
+	assert.ok(json.arguments.length > 0);
+	assert.equal(json.resultNumRows, 3);
+	assert.ok(json.child);
+	assert.equal(json.child.operationType, 'relation');
+	assert.equal(json.child.name, 'R');
+	assert.ok(!json.left);
+});
+
+
+QUnit.test('binary node (cross join)', function (assert) {
+	const relations = getTestRelations();
+	const root = exec_ra('R x S', relations);
+	root.getResult();
+	const json: any = raNodeToJSON(root);
+
+	assert.equal(json.operationType, 'crossJoin');
+	assert.equal(json.operationSymbol, '⨯');
+	assert.equal(json.resultNumRows, 25);
+	assert.ok(json.left);
+	assert.ok(json.right);
+	assert.equal(json.left.operationType, 'relation');
+	assert.equal(json.left.name, 'R');
+	assert.equal(json.right.operationType, 'relation');
+	assert.equal(json.right.name, 'S');
+	assert.ok(!json.child);
+});
+
+
+QUnit.test('deeper tree (projection on selection on cross join)', function (assert) {
+	const relations = getTestRelations();
+	const root = exec_ra('pi R.a, S.d (sigma R.b = S.b (R x S))', relations);
+	root.getResult();
+	const json: any = raNodeToJSON(root);
+
+	assert.equal(json.operationType, 'projection');
+	assert.equal(json.operationSymbol, 'π');
+	assert.equal(json.schema.columns.length, 2);
+
+	const sel = json.child;
+	assert.ok(sel);
+	assert.equal(sel.operationType, 'selection');
+	assert.equal(sel.operationSymbol, 'σ');
+
+	const join = sel.child;
+	assert.ok(join);
+	assert.equal(join.operationType, 'crossJoin');
+
+	assert.equal(join.left.operationType, 'relation');
+	assert.equal(join.left.name, 'R');
+	assert.equal(join.right.operationType, 'relation');
+	assert.equal(join.right.name, 'S');
+});
+
+
+QUnit.test('HTML entities decoded correctly', function (assert) {
+	const relations = getTestRelations();
+
+	const selRoot = exec_ra('sigma R.a > 1 (R)', relations);
+	selRoot.getResult();
+	assert.equal((raNodeToJSON(selRoot) as any).operationSymbol, 'σ');
+
+	const piRoot = exec_ra('pi R.a (R)', relations);
+	piRoot.getResult();
+	assert.equal((raNodeToJSON(piRoot) as any).operationSymbol, 'π');
+
+	const rhoRoot = exec_ra('rho X (R)', relations);
+	rhoRoot.getResult();
+	assert.equal((raNodeToJSON(rhoRoot) as any).operationSymbol, 'ρ');
+
+	const tauRoot = exec_ra('tau R.a asc (R)', relations);
+	tauRoot.getResult();
+	assert.equal((raNodeToJSON(tauRoot) as any).operationSymbol, 'τ');
+
+	const crossRoot = exec_ra('R x S', relations);
+	crossRoot.getResult();
+	assert.equal((raNodeToJSON(crossRoot) as any).operationSymbol, '⨯');
+});
+
+
+QUnit.test('operation symbol is extracted from result tree formula', function (assert) {
+	const relations = getTestRelations();
+	const child = exec_ra('R', relations);
+	const root = new FormulaOperatorNode(child);
+	root.check();
+	root.getResult();
+	const json: any = raNodeToJSON(root);
+
+	assert.equal(json.operationType, 'formulaOperator');
+	assert.equal(json.operationSymbol, '⋈');
+});
+
+
+QUnit.test('eliminate duplicates node', function (assert) {
+	const relations = getTestRelations();
+	const root = exec_bags('delta (R)', relations);
+	root.getResult();
+	const json: any = raNodeToJSON(root);
+
+	assert.equal(json.operationType, 'eliminateDuplicates');
+	assert.equal(json.operationSymbol, '∂');
+	assert.ok(json.child);
+	assert.equal(json.child.operationType, 'relation');
+});
+
+
+QUnit.test('rename relation vs rename columns', function (assert) {
+	const relations = getTestRelations();
+
+	const relRoot = exec_ra('rho X (R)', relations);
+	relRoot.getResult();
+	const relJson: any = raNodeToJSON(relRoot);
+	assert.equal(relJson.operationType, 'renameRelation');
+	assert.equal(relJson.operationSymbol, 'ρ');
+
+	const colRoot = exec_ra('rho x<-R.a (R)', relations);
+	colRoot.getResult();
+	const colJson: any = raNodeToJSON(colRoot);
+	assert.equal(colJson.operationType, 'renameColumns');
+	assert.equal(colJson.operationSymbol, 'ρ');
+});
+
+
+QUnit.test('HTML tags stripped from arguments', function (assert) {
+	const relations = getTestRelations();
+
+	const root = exec_ra('sigma R.a > 3 (R)', relations);
+	root.getResult();
+	const json: any = raNodeToJSON(root);
+
+	assert.ok(json.arguments.indexOf('<') === -1, 'no HTML tags in selection arguments');
+	assert.ok(json.arguments.indexOf('3') >= 0);
+
+	const piRoot = exec_ra('pi R.a, R.b (R)', relations);
+	piRoot.getResult();
+	const piJson: any = raNodeToJSON(piRoot);
+	assert.ok(piJson.arguments.indexOf('<') === -1, 'no HTML tags in projection arguments');
+	assert.ok(piJson.arguments.indexOf('R.a') >= 0);
+});

--- a/src/db/tests/tests.entry.ts
+++ b/src/db/tests/tests.entry.ts
@@ -13,5 +13,6 @@ import './translate_tests_bags';
 import './translate_tests_sql';
 import './translate_tests_trc';
 import './var_replacer_tests';
+import './ra_node_to_json_tests';
 
 QUnit.start();

--- a/src/locales/.json
+++ b/src/locales/.json
@@ -114,6 +114,7 @@
 	"calc.editors.ra.button-execute-query": "",
 	"calc.editors.ra.button-execute-selection": "",
 	"calc.editors.ra.button-download": "",
+	"calc.editors.ra.button-download-json": "",
 	"calc.editors.ra.toolbar.duplicate-elimination": "",
 	"calc.editors.ra.toolbar.duplicate-elimination-content": "",
 	"calc.editors.ra.toolbar.projection": "",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -273,6 +273,7 @@
 	"calc.navigation.imprint": "Impressum",
 	"calc.editors.ra.button-download-csv": "Ergebnis (CSV)",
 	"calc.editors.ra.button-download-jpg": "Ergebnis (JPG)",
+	"calc.editors.ra.button-download-json": "Ergebnis (JSON)",
 	"calc.editors.ra.button-download-query": "Query",
 	"calc.editors.ra.button-zoom-center": "Ansicht einpassen",
 	"calc.editors.ra.button-zoom-in": "Hereinzoomen",

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -133,6 +133,7 @@ export const langDE: Partial<typeof langEN> = {
 	'calc.editors.ra.button-download': 'Download',
 	'calc.editors.ra.button-download-csv': 'Ergebnis (CSV)',
 	'calc.editors.ra.button-download-jpg': 'Ergebnis (JPG)',
+	'calc.editors.ra.button-download-json': 'Ergebnis (JSON)',
 	'calc.editors.ra.button-download-query': 'Query',
 	'calc.editors.ra.button-zoom-in': 'Hereinzoomen',
 	'calc.editors.ra.button-zoom-out': 'Herauszoomen',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -273,6 +273,7 @@
 	"calc.navigation.imprint": "Imprint",
 	"calc.editors.ra.button-download-csv": "Result (CSV)",
 	"calc.editors.ra.button-download-jpg": "Result (JPG)",
+	"calc.editors.ra.button-download-json": "Result (JSON)",
 	"calc.editors.ra.button-download-query": "Query",
 	"calc.editors.ra.button-zoom-center": "Zoom to fit",
 	"calc.editors.ra.button-zoom-in": "Zoom in",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -134,6 +134,7 @@ export const langEN = {
 	'calc.editors.ra.button-download': 'Download CSV',
 	'calc.editors.ra.button-download-csv': 'Result (CSV)',
 	'calc.editors.ra.button-download-jpg': 'Result (JPG)',
+	'calc.editors.ra.button-download-json': 'Result (JSON)',
 	'calc.editors.ra.button-download-query': 'Query',
 	'calc.editors.ra.button-zoom-in': 'Zoom in',
 	'calc.editors.ra.button-zoom-out': 'Zoom out',

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -273,6 +273,7 @@
 	"calc.navigation.imprint": "Imprimir",
 	"calc.editors.ra.button-download-csv": "Resultado (CSV)",
 	"calc.editors.ra.button-download-jpg": "Resultado (JPG)",
+	"calc.editors.ra.button-download-json": "Resultado (JSON)",
 	"calc.editors.ra.button-download-query": "Consulta",
 	"calc.editors.ra.button-zoom-center": "Ajustar a la vista",
 	"calc.editors.ra.button-zoom-in": "Acercar",

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -143,6 +143,7 @@ export const langES: Partial<typeof langEN> = {
   'calc.editors.ra.button-execute-selection': 'ejecutar selección',
   'calc.editors.ra.button-download': 'Descargar',
   'calc.editors.ra.button-download-csv': 'Resultado (CSV)',
+  'calc.editors.ra.button-download-json': 'Resultado (JSON)',
   'calc.editors.ra.button-download-query': 'Consulta',
   'calc.editors.ra.button-zoom-in': 'Acercar',
   'calc.editors.ra.button-zoom-out': 'Alejar',

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -224,6 +224,7 @@
 	"calc.navigation.imprint": "Impressum",
 	"calc.editors.ra.button-download-csv": "Risultato (CSV)",
 	"calc.editors.ra.button-download-jpg": "Risultato (JPG)",
+	"calc.editors.ra.button-download-json": "Risultato (JSON)",
 	"calc.editors.ra.button-download-query": "Query",
 	"calc.editors.ra.button-zoom-center": "Centra",
 	"calc.editors.ra.button-zoom-in": "Ingrandisci",

--- a/src/locales/kr.json
+++ b/src/locales/kr.json
@@ -273,6 +273,7 @@
 	"calc.navigation.imprint": "Imprint",
 	"calc.editors.ra.button-download-csv": "결과 (CSV)",
 	"calc.editors.ra.button-download-jpg": "결과 (JPG)",
+	"calc.editors.ra.button-download-json": "결과 (JSON)",
 	"calc.editors.ra.button-download-query": "쿼리",
 	"calc.editors.ra.button-zoom-center": "뷰에 맞추기",
 	"calc.editors.ra.button-zoom-in": "줌인",

--- a/src/locales/kr.ts
+++ b/src/locales/kr.ts
@@ -115,6 +115,7 @@ export const langKR = {
 	'calc.editors.ra.button-download': '다운로드',
     'calc.editors.ra.button-download-csv': '결과 (CSV)',
 	'calc.editors.ra.button-download-jpg': '결과 (JPG)',
+	'calc.editors.ra.button-download-json': '결과 (JSON)',
     'calc.editors.ra.button-download-query': '쿼리',
 	'calc.editors.ra.button-zoom-in': '줌인',
 	'calc.editors.ra.button-zoom-out': '줌아웃',

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -273,6 +273,7 @@
 	"calc.navigation.imprint": "Impress\u00e3o",
 	"calc.editors.ra.button-download-csv": "Resultado (CSV)",
 	"calc.editors.ra.button-download-jpg": "Resultado (JPG)",
+	"calc.editors.ra.button-download-json": "Resultado (JSON)",
 	"calc.editors.ra.button-download-query": "Consulta",
 	"calc.editors.ra.button-zoom-center": "Ajustar \u00e0 visualiza\u00e7\u00e3o",
 	"calc.editors.ra.button-zoom-in": "Aumentar zoom",

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -102,6 +102,7 @@ export const langPT = {
       '<div><b>(</b> A <b>) <span class="math">&cap;</span> (</b> B <b>)</b></div>',
     'calc.editors.ra.button-download': 'baixar',
     'calc.editors.ra.button-download-csv': 'Resultado (CSV)',
+    'calc.editors.ra.button-download-json': 'Resultado (JSON)',
     'calc.editors.ra.button-download-query': 'Consulta',
     'calc.editors.ra.button-zoom-in': 'Aumentar zoom',
     'calc.editors.ra.button-zoom-out': 'Diminuir zoom',


### PR DESCRIPTION
  Adds the ability to export the execution plan as a JSON file, alongside the existing CSV and JPG download options.

     The JSON output includes the full operator tree with:
     - Operation types (`selection`, `projection`, `crossJoin`, `renameRelation`, `renameColumns`, etc.)
     - Unicode operator symbols (σ, π, ρ, ⨯, etc.)
     - Operator arguments (conditions, column lists)
     - Result row counts and output schemas

     ## Changes
     - `raNodeToJSON()` serializer in `RANode.ts`
     - JSON download button in `editorBase.tsx`
     - i18n keys for all 7 supported languages
     - 8 QUnit tests covering all node arities, HTML decoding, and operator disambiguation

     ## Test plan
     - [x] `yarn build` passes
     - [x] 726 QUnit tests pass (0 failures)
     - [x] JSON download button appears in dropdown after executing a query
     - [x] Downloaded JSON contains correct tree structure with types, symbols, arguments, schemas, and row counts

     Closes #196