### PR TITLE
Fix natural join handling for duplicate column names and aliases

### DIFF
--- a/src/db/exec/joins/Join.ts
+++ b/src/db/exec/joins/Join.ts
@@ -511,10 +511,15 @@ export abstract class Join extends RANodeBinary {
 				// skip all but certain columns (for joins with USING())
 				continue;
 			}
-			
-			let indices = [];
+
+			// If there are duplicate columns, try to match by name only if alias match yields nothing
+			let indices: number[] = [];
 			if (hasDuplicateCols) {
 				indices = schemaB.getColumnIndexArray(a.getName(), a.getRelAlias());
+				// If no match found with alias, try without alias (by name only)
+				if (indices.length === 0) {
+					indices = schemaB.getColumnIndexArray(a.getName(), null);
+				}
 			} else {
 				indices = schemaB.getColumnIndexArray(a.getName(), null);
 			}


### PR DESCRIPTION
# Reference issues

https://github.com/dbis-uibk/relax/issues/290

# What does this implement/fix?

This PR fixes the fallback logic in Join.getNaturalJoinConditionArray. The problem occurred specifically when one of the schemas involved in the join had columns with the same name but different aliases (result of a theta join). Previously, when duplicate columns were present, the join condition would only match columns by both name and alias, which could result in missing matches if the alias did not exist in the other schema. Now, if no match is found by alias, the code falls back to matching by name only, ensuring correct join behavior even with duplicate columns and aliases.

This seems to resolve these edge cases and not affectthe join behavior when columns are unique.

<img width="1436" height="778" alt="Screenshot 2026-05-22 at 11 56 19" src="https://github.com/user-attachments/assets/dda24343-4c02-417c-be12-96c1f6625e25" />
