### PR TITLE
Restrict history dropdown item width and truncate long entries

### DIFF
--- a/src/calc2/components/editorBase.scss
+++ b/src/calc2/components/editorBase.scss
@@ -1,0 +1,7 @@
+.history-dropdown-item {
+  max-width: 300px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}

--- a/src/calc2/components/editorBase.tsx
+++ b/src/calc2/components/editorBase.tsx
@@ -47,6 +47,7 @@ require('codemirror/addon/display/placeholder.js');
 require('codemirror/addon/display/autorefresh.js');
 require('codemirror/mode/sql/sql.js');
 require('handsontable/dist/handsontable.full.css');
+require('./editorBase.scss');
 
 CodeMirror.defineMode('trc', function () {
 	const keywords = ['in', 'and', 'or', 'xor', 'not', 'implies', 'iff', 'exists', 'for all', 'not between', 'between'];
@@ -1211,7 +1212,7 @@ export class EditorBase extends React.Component<Props, State> {
 													label: (
 														<>
 															<small className="muted text-muted">{h.time.toLocaleTimeString()}</small>
-															<div>{h.code}</div>
+															<div className="history-dropdown-item">{h.code}</div>
 															{/*
 															// colorize the code
 															codeNode.addClass('colorize');


### PR DESCRIPTION
# Reference issues

None.

# What does this implement/fix?

This PR improves the history dropdown rendering by constraining the width of history items and truncating long code entries with an ellipsis (`...`). Long history entries could expand the dropdown width or reduce readability. This change keeps the dropdown compact and improves UX by ensuring long queries/code snippets are visually truncated while remaining identifiable.

- Before:

<img width="1437" height="781" alt="Screenshot 2026-05-22 at 14 29 38" src="https://github.com/user-attachments/assets/63073439-22c0-436e-acbe-d7a739a5bf95" />

- After:

<img width="1436" height="779" alt="Screenshot 2026-05-22 at 14 30 01" src="https://github.com/user-attachments/assets/8550451f-e8df-49e9-a188-b2a534a9c9df" />

