### PR TITLE
Improve editor UX by disabling unavailable actions

### DIFF
--- a/src/calc2/components/dropdownList.tsx
+++ b/src/calc2/components/dropdownList.tsx
@@ -31,6 +31,7 @@ export type DropdownElement<V> = (
 		label: string | JSX.Element,
 		value: V,
 		active?: boolean,
+		disabled?: boolean,
 	}
 );
 
@@ -83,6 +84,7 @@ export class DropdownList<V = string> extends React.Component<Props<V>, State> {
 										onChange && onChange(e.value);
 									}}
 									active={e.active || e.value === value}
+									disabled={e.disabled}
 								>
 									{e.label}
 								</DropdownItem>

--- a/src/calc2/components/editorBase.scss
+++ b/src/calc2/components/editorBase.scss
@@ -1,5 +1,5 @@
 .dropdown-item:disabled {
-	opacity: 0.5;
+	opacity: 0.65;
 	cursor: not-allowed;
 	pointer-events: none;
 }

--- a/src/calc2/components/editorBase.scss
+++ b/src/calc2/components/editorBase.scss
@@ -1,0 +1,5 @@
+.dropdown-item:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+	pointer-events: none;
+}

--- a/src/calc2/components/editorBase.tsx
+++ b/src/calc2/components/editorBase.tsx
@@ -1125,6 +1125,10 @@ export class EditorBase extends React.Component<Props, State> {
 			execButtonLabel,
 		} = this.props;
 
+		const hasEditorContent =
+			!!editor && editor.getValue().trim().length > 0;
+		const hasQueryResult = !!queryResult;
+
 		return (
 			<div>
 				<div className="editor-base">
@@ -1140,12 +1144,12 @@ export class EditorBase extends React.Component<Props, State> {
 					<div className="input-buttons">
 						<button
 							type="button"
-							disabled={isExecutionDisabled}
+							disabled={isExecutionDisabled || !hasEditorContent}
 							className={classNames('btn btn-primary exec-button selection', {
 								'selection-selected': isSelectionSelected,
 								'btn-danger': execErrors.length > 0,
 								'btn-success': execSuccessful,
-								'disabled': isExecutionDisabled,
+								'disabled': isExecutionDisabled || !hasEditorContent,
 							})}
 							onClick={() => {
 								if (!editor) {
@@ -1177,6 +1181,7 @@ export class EditorBase extends React.Component<Props, State> {
 											</>
 											),
 									 	value: '',
+										disabled: !hasEditorContent,
 									},
 									{
 										label: (
@@ -1185,6 +1190,7 @@ export class EditorBase extends React.Component<Props, State> {
 											</>
 											),
 									 	value: '',
+										disabled: !hasQueryResult,
 									},
 									{
 										label: (
@@ -1193,6 +1199,7 @@ export class EditorBase extends React.Component<Props, State> {
 											</>
 											),
 									 	value: '',
+										disabled: !hasQueryResult,
 									},
 									]
 										


### PR DESCRIPTION
# Reference issues

None.

# What does this implement/fix?

This PR improves the user experience by preventing actions that cannot be completed and by providing clearer visual feedback about action availability.

To support this behavior, conditional disabling of individual dropdown menu items was added to the `DropdownList` component.

The editor now automatically enables or disables actions based on the current state:

- **Execute query** is disabled when the editor is empty;
- **Query download** is disabled when the editor is empty;
- **CSV** and **JPG result downloads** are disabled when no query result is available.

This prevents invalid interactions, avoids unnecessary feedback/errors, and makes the interface behavior more predictable and intuitive.

- Before:

<img width="1434" height="774" alt="Screenshot 2026-05-22 at 16 42 04" src="https://github.com/user-attachments/assets/87ac4a20-0a4b-4f54-be7a-6e79a5e82baf" />

- After:

<img width="1431" height="776" alt="Screenshot 2026-05-22 at 16 47 20" src="https://github.com/user-attachments/assets/1531618a-5d15-4165-8a92-72f4604f1330" />

<img width="1427" height="773" alt="Screenshot 2026-05-22 at 16 44 16" src="https://github.com/user-attachments/assets/2652a22f-6c50-4446-8bdb-50dd5301cd8b" />

<img width="1433" height="776" alt="Screenshot 2026-05-22 at 16 48 34" src="https://github.com/user-attachments/assets/039fa734-24a3-4ec1-8f19-82adaf91b77d" />

And if I delete the query `execute query` and `download query` are automatically disabled.

<img width="1431" height="774" alt="Screenshot 2026-05-22 at 16 49 35" src="https://github.com/user-attachments/assets/be9cb3ac-1503-4786-a782-4046dcc5e703" />
