### PR TITLE
Reset pagination on node selection (execution tree)

### DIFF
--- a/src/calc2/components/pagedTable.tsx
+++ b/src/calc2/components/pagedTable.tsx
@@ -31,6 +31,10 @@ export class PagedTable extends React.Component<Props, State> {
 		};
 	}
 
+	resetPage(): void {
+		this.setState({ page: 0 });
+	}
+
 	render() {
 		const { table, maxLinesPerPage, showPagination = true, className = '' } = this.props;
 		const { page } = this.state;

--- a/src/calc2/components/raTree.tsx
+++ b/src/calc2/components/raTree.tsx
@@ -25,6 +25,7 @@ interface Props {
 	numTreeLabelColors?: number,
 	setActiveNode?(activeNode: RANode): void,
 	doEliminateDuplicates?: boolean,
+	onNodeClick?(node: RANode): void,
 }
 
 export class RaTree extends React.Component<Props> {
@@ -135,7 +136,10 @@ export class RaTree extends React.Component<Props> {
 							'node': true,
 							'active': n === activeNode,
 						})}
-						onClick={() => setActiveNode && setActiveNode(n)}
+						onClick={() => {
+							setActiveNode && setActiveNode(n);
+							this.props.onNodeClick && this.props.onNodeClick(n);
+						}}
 					>
 						<Popover
 							title={<div>{fromVariableMarker}<div dangerouslySetInnerHTML={{ __html: n.getFormulaHtml(true, false) }}></div></div>}

--- a/src/calc2/components/result.tsx
+++ b/src/calc2/components/result.tsx
@@ -46,6 +46,8 @@ export class Result extends React.Component<Props, State> {
 		},
 	);
 
+	private pagedTableRef = React.createRef<PagedTable>();
+
 	constructor(props: Props) {
 		super(props);
 
@@ -63,6 +65,11 @@ export class Result extends React.Component<Props, State> {
 		this.setState({
 			activeNode,
 		});
+
+		// Reset pagination when a new node is selected
+		if (this.pagedTableRef.current) {
+			this.pagedTableRef.current.resetPage();
+		}
 	}
 
 	render() {
@@ -84,6 +91,7 @@ export class Result extends React.Component<Props, State> {
 						activeNode={activeNode}
 						numTreeLabelColors={numTreeLabelColors}
 						setActiveNode={this.setActiveNode}
+						onNodeClick={this.setActiveNode}
 					/>
 				</div>
 
@@ -102,6 +110,7 @@ export class Result extends React.Component<Props, State> {
 							{result
 								? (
 									<PagedTable
+										ref={this.pagedTableRef}
 										className="table table-condensed"
 										maxLinesPerPage={maxLinesPerPage}
 										table={result}


### PR DESCRIPTION
# Reference issues

https://github.com/dbis-uibk/relax/issues/288

# What does this implement/fix?

This PR automatically resets pagination when selecting nodes in the execution tree, ensuring that the result table always starts on page 1 when viewing a different intermediate result.

Previously, when users clicked on different nodes in the tree to view intermediate query results, the pagination remained at the last viewed page. This could be confusing as users would see no tuples or results from the middle of the dataset without context.

https://github.com/user-attachments/assets/2b23c0af-5f57-4de0-872e-b4398c58be56
