### PR TITLE
Fix natural full outer join

### DIFF
--- a/src/db/exec/joins/FullOuterJoin.ts
+++ b/src/db/exec/joins/FullOuterJoin.ts
@@ -24,6 +24,9 @@ import { Join, JoinCondition } from './Join';
  * @returns {FullOuterJoin}
  */
 export class FullOuterJoin extends Join {
+	private keepColumns: any = null;
+	private isNaturalJoin: boolean = false;
+
 	constructor(child: RANode, child2: RANode, condition: JoinCondition) {
 		super(child, child2, '⟗', condition, false);
 	}
@@ -36,20 +39,38 @@ export class FullOuterJoin extends Join {
 		try {
 			// full outer join always has a concatenated schema
 
-			// check columns appearing in both schemas
-			const conflicts = schemaA.getConflictingColumnsArray(schemaB);
-			if (conflicts.length > 0) {
-				this.throwExecutionError(i18n.t('db.messages.exec.error-join-would-produce-non-unique-columns', { conflicts: conflicts.join(', ') }));
+			if (this._joinConditionOptions.type === 'natural') {
+				this.isNaturalJoin = true;
+				const tmp = Schema.concatNatural(schemaA, schemaB, true, this._joinConditionOptions.restrictToColumns);
+				this.keepColumns = tmp.keep;
+
+				this._schema = tmp.schema;
+				this._rowCreatorMatched = (rowA: any[], rowB: any[]): any[] => {
+					return Join.createNaturalRowArray(rowA, rowB, this.keepColumns.size, this.keepColumns.keepIndicesA, this.keepColumns.keepIndicesB);
+				};
+				this._rowCreatorNotMatched = (rowA: any[], rowB: any[]): any[] => {
+					return Join.createNaturalRowArray(rowA, rowB, this.keepColumns.size, this.keepColumns.keepIndicesA, this.keepColumns.keepIndicesB);
+				};
+
 			}
+			else {
+				// theta join
+				this.isNaturalJoin = false;
 
-			this._schema = Schema.concat(this._child.getSchema(), this._child2.getSchema());
-			this._rowCreatorMatched = function (rowA: any[], rowB: any[]): any[] {
-				return rowA.concat(rowB);
-			};
-			this._rowCreatorNotMatched = function (rowA: any[], rowB: any[]): any[] {
-				return rowA.concat(rowB);
-			};
+				// check columns appearing in both schemas
+				const conflicts = schemaA.getConflictingColumnsArray(schemaB);
+				if (conflicts.length > 0) {
+					this.throwExecutionError(i18n.t('db.messages.exec.error-join-would-produce-non-unique-columns', { conflicts: conflicts.join(', ') }));
+				}
 
+				this._schema = Schema.concat(this._child.getSchema(), this._child2.getSchema());
+				this._rowCreatorMatched = function (rowA: any[], rowB: any[]): any[] {
+					return rowA.concat(rowB);
+				};
+				this._rowCreatorNotMatched = function (rowA: any[], rowB: any[]): any[] {
+					return rowA.concat(rowB);
+				};
+			}
 		}
 		catch (e) {
 			// throw (new) error in the join-context
@@ -67,6 +88,79 @@ export class FullOuterJoin extends Join {
 		const resultTable = new Table();
 		resultTable.setSchema(this.getSchema());
 
+		let leftUnmatchedCreator: ((rowA: any[], rowB: any[]) => any[]) | null = this._rowCreatorNotMatched;
+		let rightUnmatchedCreator: ((rowA: any[], rowB: any[]) => any[]) | null = this._rowCreatorNotMatched;
+
+		if (this.isNaturalJoin && this.keepColumns) {
+			const keepColumns = this.keepColumns;
+			const schemaA = this.getChild().getSchema();
+			const schemaB = this.getChild2().getSchema();
+
+			// Identify common column names between A and B
+			const commonColumnNames = new Set<string | number>();
+			for (let i = 0; i < schemaA.getSize(); i++) {
+				const colName = schemaA.getColumn(i).getName();
+				for (let j = 0; j < schemaB.getSize(); j++) {
+					if (schemaB.getColumn(j).getName() === colName) {
+						commonColumnNames.add(colName);
+						break;
+					}
+				}
+			}
+
+			// For unmatched left rows: values from left, NULLs for right-only columns
+			leftUnmatchedCreator = (rowA: any[], rowB: any[]): any[] => {
+				const nullRow = new Array(schemaB.getSize()).fill(null);
+				return Join.createNaturalRowArray(rowA, nullRow, keepColumns.size, keepColumns.keepIndicesA, keepColumns.keepIndicesB);
+			};
+
+			// For unmatched right rows: construct row with proper handling of common columns
+			rightUnmatchedCreator = (rowA: any[], rowB: any[]): any[] => {
+				const row = new Array(keepColumns.size);
+				let col = 0;
+
+				// Fill columns from A (left): NULLs for left-only, values from B for common
+				for (let k = 0; k < keepColumns.keepIndicesA.length; k++) {
+					const colName = schemaA.getColumn(keepColumns.keepIndicesA[k]).getName();
+					if (commonColumnNames.has(colName)) {
+						// Common column: find it in B and use its value
+						for (let j = 0; j < schemaB.getSize(); j++) {
+							if (schemaB.getColumn(j).getName() === colName) {
+								row[col++] = rowB[j];
+								break;
+							}
+						}
+					} else {
+						// Left-only column: use NULL
+						row[col++] = null;
+					}
+				}
+
+				// Fill columns from B (right): only right-only columns
+				for (let k = 0; k < keepColumns.keepIndicesB.length; k++) {
+					row[col++] = rowB[keepColumns.keepIndicesB[k]];
+				}
+
+				return row;
+			};
+		} else {
+			// Theta join (not natural): all columns are kept
+			const schemaA = this.getChild().getSchema();
+			const schemaB = this.getChild2().getSchema();
+			const numColsA = schemaA.getSize();
+			const numColsB = schemaB.getSize();
+
+			// For unmatched left rows: left values + NULLs for all right columns
+			leftUnmatchedCreator = (rowA: any[], rowB: any[]): any[] => {
+				return rowA.concat(new Array(numColsB).fill(null));
+			};
+
+			// For unmatched right rows: NULLs for all left columns + right values
+			rightUnmatchedCreator = (rowA: any[], rowB: any[]): any[] => {
+				return new Array(numColsA).fill(null).concat(rowB);
+			};
+		}
+
 		// left join
 		Join.calcNestedLoopJoin(
 			doEliminateDuplicateRows,
@@ -77,7 +171,7 @@ export class FullOuterJoin extends Join {
 			false,
 			this._joinConditionEvaluator,
 			this._rowCreatorMatched,
-			this._rowCreatorNotMatched,
+			leftUnmatchedCreator,
 		);
 
 		// right join
@@ -92,7 +186,7 @@ export class FullOuterJoin extends Join {
 			// Should not create matched rows twice in case of a multiset (left join already did the job)
 			// this._rowCreatorMatched,	
 			null,
-			this._rowCreatorNotMatched,
+			rightUnmatchedCreator,
 		);
 
 		if (doEliminateDuplicateRows === true) {

--- a/src/db/tests/translate_tests_bags.ts
+++ b/src/db/tests/translate_tests_bags.ts
@@ -405,8 +405,31 @@ QUnit.test('test bag groupBy a; sum[b] (R2)', function (assert) {
 	assert.deepEqual(root.getResult(false), ref.getResult(false));
 });
 
-QUnit.test('test (R2) bag outer join (S2)', function (assert) {
+QUnit.test('test (R2) bag full natural outer join (S2)', function (assert) {
 	const query = '(R2) full outer join (S2)';
+	const relations = getTestBags();
+	const root = exec_ra(query, relations);
+
+	const ref = exec_ra(`{
+		R.a:number, R.b:number, S.c:number
+
+		0,   1,   null
+		2,   3,   4
+		2,   3,   4
+		0,   1,   null
+		2,   4,   null
+		3,   4,   null
+		null,0,   1
+		null,2,   4
+		null,2,   5
+		null,0,   2
+	}`, relations);
+
+	assert.deepEqual(root.getResult(false), ref.getResult(false));
+});
+
+QUnit.test('test (R2) bag full theta outer join (S2)', function (assert) {
+	const query = '(R2) full outer join R2.b = S2.b (S2)';
 	const relations = getTestBags();
 	const root = exec_ra(query, relations);
 

--- a/src/db/tests/translate_tests_ra.ts
+++ b/src/db/tests/translate_tests_ra.ts
@@ -891,7 +891,7 @@ QUnit.test('test rightOuterJoin 0', function (assert) {
 	assert.deepEqual(root.getResult(), ref.getResult());
 });
 
-QUnit.test('test fullOuterJoin 0', function (assert) {
+QUnit.test('test fullThetaOuterJoin', function (assert) {
 	const query = '(T) full outer join T.b=S.b (S)';
 	const root = exec_ra(query, getTestRelations());
 
@@ -910,20 +910,20 @@ QUnit.test('test fullOuterJoin 0', function (assert) {
 	assert.deepEqual(root.getResult(), ref.getResult());
 });
 
-QUnit.test('test fullOuterJoin (natural)', function (assert) {
+QUnit.test('test fullNaturalOuterJoin', function (assert) {
 	const query = '(T) full outer join (S)';
 	const root = exec_ra(query, getTestRelations());
 
 	const ref = exec_ra(`{
-		T.b, T.d, S.b, S.d
+		T.b, T.d
 
-		'a',  100,  'a',  100
-		'd',  200,  'd',  200
-		'f',  400,  null, null
-		'g',  120,  null, null
-		null, null, 'b',  300
-		null, null, 'c',  400
-		null, null, 'e',  150
+		'a',  100
+		'd',  200
+		'f',  400
+		'g',  120
+		'b',  300
+		'c',  400
+		'e',  150
 	}`, {});
 
 	assert.deepEqual(root.getResult(), ref.getResult());


### PR DESCRIPTION
# Reference issues

None.

# What does this implement/fix?

This PR fixes critical issues in natural full outer join operations, ensuring proper NULL handling for unmatched tuples and correct column name preservation.

Previously, natural full outer joins were not properly supported. The main issues were:
  - Redundant columns (common columns appearing in both relations) were not properly suppressed in the result schema;
  - Concatenation of unmatched tuples was not straightforward for natural joins — when  right tuples didn't find matches in the left relation, common column values were lost and replaced with NULL or undefined instead of preserving the actual values from the right tuple;
  - Only theta full outer joins worked correctly.

  ```sql
  -- Example 01
  R ⟗ R
  ```
  <img width="1436" height="775" alt="Screenshot 2026-05-23 at 13 11 56" src="https://github.com/user-attachments/assets/80fc5bb1-000a-4c9f-a08e-0c0402fb3c3b" />

  ```sql
  -- Example 02
  R ⟗ S
  ```
  <img width="1436" height="777" alt="Screenshot 2026-05-23 at 13 16 58" src="https://github.com/user-attachments/assets/73563993-cd11-4753-bfd9-4c7adb91d9d2" />

This PR refactored the full outer join implementation, in particular:
- Implemented identification and handling of common columns between relations;
- For unmatched left rows: Used left values with NULLs for right-only columns;
- For unmatched right rows: Preserved common column values from the right relation and used NULLs only for left-only columns;
- Added unit tests for natural full outer joins with various scenarios;

  ```sql
  -- Example 01
  R ⟗ R
  ```
  <img width="1438" height="773" alt="Screenshot 2026-05-23 at 13 31 26" src="https://github.com/user-attachments/assets/a62fcc35-62a8-4317-92ff-4704cd3a9707" />

  ```sql
  -- Example 02
  R ⟗ S
  ```
  <img width="1437" height="774" alt="Screenshot 2026-05-23 at 13 32 32" src="https://github.com/user-attachments/assets/27702c97-c069-4730-9138-13457f92a623" />
